### PR TITLE
feat: add foundation module with MVI implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.module.library.foundation)
+
             implementation(libs.bundles.compose)
             implementation(libs.koin.compose)
         }

--- a/module/library/foundation/build.gradle.kts
+++ b/module/library/foundation/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.gradleBuildConfig)
+    alias(libs.plugins.kotlinMultiplatform)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(libs.kermit)
+            implementation(libs.kotlinx.coroutines.core)
+        }
+        commonTest.dependencies {
+            implementation(libs.bundles.unitTest)
+        }
+    }
+}
+
+android {
+    namespace = "kmp.template.foundation"
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/flow/CompletableFlow.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/flow/CompletableFlow.kt
@@ -1,0 +1,32 @@
+package kmp.template.foundation.flow
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+
+class CompletableFlow<T>(
+    private val flow: Flow<T>,
+    private val result: MutableList<T> = mutableListOf(),
+    private var job: Job? = null
+) {
+
+    fun collect(coroutineScope: CoroutineScope) {
+        job?.cancel()
+        job = coroutineScope.launch {
+            flow.toList(result)
+        }
+    }
+
+    fun complete(): List<T> {
+        job?.cancel()
+        job = null
+        return result.toList()
+    }
+
+    companion object {
+        fun <T> Flow<T>.collect(scope: CoroutineScope): CompletableFlow<T> =
+            CompletableFlow(flow = this).apply { collect(scope) }
+    }
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/MviContainer.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/MviContainer.kt
@@ -1,0 +1,34 @@
+package kmp.template.foundation.mvi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Container which implements MVI (Redux) architecture pattern.
+ * ```
+ *     +----UI----+                       +--Container--+         +----DOMAIN----+
+ *     |          |  -----( intent )--->  |             |  ---->  |  use case    |
+ *     | compose  |                       |  ViewModel  |         |  repository  |
+ *     |          |  <--( viewState )---  |             |  <----  |  controller  |
+ *     +----------+    ( or sideEffect )  +-------------+         +--------------+
+ * ```
+ * Components:
+ *   - Intent - represents interaction from UI ([MviContainer.launch] method)
+ *   - Transformer - transforms current UI state to new state ([MviContainer.transform] method)
+ *   - ViewState - representation of UI state ([MviContainer.viewState] data flow)
+ *   - SideEffect - side effects events data ([MviContainer.sideEffect] data flow)
+ */
+interface MviContainer<ViewState> {
+
+    val viewState: StateFlow<ViewState>
+
+    val sideEffect: Flow<Any>
+
+    fun launch(intent: suspend CoroutineScope.() -> Unit): Job
+
+    fun transform(transformer: ViewState.() -> ViewState)
+
+    fun emitSideEffect(sideEffect: Any)
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/MviViewModel.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/MviViewModel.kt
@@ -1,0 +1,45 @@
+package kmp.template.foundation.mvi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kmp.template.foundation.mvi.config.MviConfig
+import kmp.template.foundation.mvi.config.MviDefaultConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+open class MviViewModel<ViewState>(
+    initialState: ViewState,
+    private val config: MviConfig = MviDefaultConfig()
+) : ViewModel(), MviContainer<ViewState> {
+
+    private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(initialState)
+    override val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    private val _sideEffect: Channel<Any> = Channel()
+    override val sideEffect: Flow<Any> = _sideEffect.receiveAsFlow()
+
+    override fun launch(intent: suspend CoroutineScope.() -> Unit): Job =
+        launchJob(intent::invoke)
+
+    override fun transform(transformer: ViewState.() -> ViewState) {
+        _viewState.update(transformer::invoke)
+    }
+
+    override fun emitSideEffect(sideEffect: Any) {
+        launchJob { _sideEffect.send(sideEffect) }
+    }
+
+    private fun launchJob(intent: suspend CoroutineScope.() -> Unit): Job =
+        viewModelScope.launch(
+            context = config.launchDispatcher + config.exceptionHandler,
+            block = intent::invoke
+        )
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviConfig.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviConfig.kt
@@ -1,0 +1,23 @@
+package kmp.template.foundation.mvi.config
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Configuration interface for MVI (Redux) architecture.
+ *
+ * Implementation of this interface can be added to the DI graph.
+ */
+interface MviConfig {
+
+    /**
+     * Managing exceptions not handled directly in MVI Intents
+     */
+    val exceptionHandler: CoroutineExceptionHandler
+
+    /**
+     * MVI Intents based coroutine dispatcher, recommended [Dispatchers.Main]
+     */
+    val launchDispatcher: CoroutineDispatcher
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviDefaultConfig.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviDefaultConfig.kt
@@ -1,0 +1,14 @@
+package kmp.template.foundation.mvi.config
+
+import kmp.template.foundation.mvi.config.dispatcher.MviDispatcher
+import kmp.template.foundation.mvi.config.exception.MviExceptionHandler
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+/**
+ * Default, minimalistic MVI (Redux) container configuration.
+ */
+data class MviDefaultConfig(
+    override val exceptionHandler: CoroutineExceptionHandler = MviExceptionHandler(),
+    override val launchDispatcher: CoroutineDispatcher = MviDispatcher.main
+) : MviConfig

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviTestConfig.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviTestConfig.kt
@@ -1,0 +1,13 @@
+package kmp.template.foundation.mvi.config
+
+import kmp.template.foundation.mvi.config.exception.MviTestExceptionHandler
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+/**
+ * Unit test MVI (Redux) container configuration.
+ */
+class MviTestConfig(testDispatcher: CoroutineDispatcher) : MviConfig {
+    override val exceptionHandler: CoroutineExceptionHandler = MviTestExceptionHandler()
+    override val launchDispatcher: CoroutineDispatcher = testDispatcher
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/dispatcher/MviDispatcher.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/dispatcher/MviDispatcher.kt
@@ -1,0 +1,12 @@
+package kmp.template.foundation.mvi.config.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Default dispatchers used in MVI (Redux) container implementation.
+ */
+internal object MviDispatcher {
+
+    val main: CoroutineDispatcher = Dispatchers.Main
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/exception/MviExceptionHandler.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/exception/MviExceptionHandler.kt
@@ -1,0 +1,21 @@
+package kmp.template.foundation.mvi.config.exception
+
+import co.touchlab.kermit.Logger
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+/**
+ * Fallback MVI (Redux) exception handler.
+ *
+ * This exception handler is called for exceptions which are not handled directly in MVI Intents.
+ */
+internal class MviExceptionHandler :
+    AbstractCoroutineContextElement(CoroutineExceptionHandler),
+    CoroutineExceptionHandler {
+
+    override fun handleException(
+        context: CoroutineContext,
+        exception: Throwable
+    ) = Logger.e(exception) { "MVI exception handler" }
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/exception/MviTestExceptionHandler.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/exception/MviTestExceptionHandler.kt
@@ -1,0 +1,18 @@
+package kmp.template.foundation.mvi.config.exception
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+/**
+ * Test MVI (Redux) exception handler - always throws an exception.
+ */
+internal class MviTestExceptionHandler :
+    AbstractCoroutineContextElement(CoroutineExceptionHandler),
+    CoroutineExceptionHandler {
+
+    override fun handleException(
+        context: CoroutineContext,
+        exception: Throwable
+    ) = throw exception
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/usecase/UseCase.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/usecase/UseCase.kt
@@ -1,0 +1,18 @@
+package kmp.template.foundation.usecase
+
+/**
+ * Use case interface - represents business logic unit operation.
+ *
+ * @param IN input data type
+ * @param OUT output data type
+ */
+interface UseCase<IN : Any, OUT : Any> {
+    suspend operator fun invoke(input: IN): OUT
+}
+
+/**
+ * Use case extension function - invokes use case without input data.
+ *
+ * @param OUT output data type
+ */
+suspend operator fun <OUT : Any> UseCase<Unit, OUT>.invoke(): OUT = invoke(Unit)

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/flow/CompletableFlowTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/flow/CompletableFlowTest.kt
@@ -1,0 +1,97 @@
+package kmp.template.foundation.flow
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kmp.template.foundation.flow.CompletableFlow.Companion.collect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CompletableFlowTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun `returns list of states and cancel collection when complete is triggered`() = runTest(dispatcher) {
+        val flow = MutableStateFlow(INITIAL_STATE)
+        val tested = flow.collect(scope = this)
+
+        flow.emit(NEW_STATE)
+
+        assertEquals(listOf(INITIAL_STATE, NEW_STATE), tested.complete())
+    }
+
+    @Test
+    fun `returns list with init state when complete is triggered on state flow`() = runTest(dispatcher) {
+        val flow = MutableStateFlow(INITIAL_STATE).asStateFlow()
+
+        val tested = flow.collect(scope = this)
+
+        assertEquals(listOf(INITIAL_STATE), tested.complete())
+    }
+
+    @Test
+    fun `returns empty list of states when complete is triggered on flow`() = runTest(dispatcher) {
+        val flow = emptyFlow<String>()
+
+        val tested = flow.collect(scope = this)
+
+        assertEquals(emptyList(), tested.complete())
+    }
+
+    @Test
+    fun `returns empty list of states when complete is triggered on shared flow`() = runTest(dispatcher) {
+        val flow = MutableSharedFlow<String>()
+
+        val tested = flow.collect(scope = this)
+
+        assertEquals(emptyList(), tested.complete())
+    }
+
+    @Test
+    fun `returns list with init state when complete is triggered multiple times`() = runTest(dispatcher) {
+        val flow = MutableStateFlow(INITIAL_STATE)
+        val tested = flow.collect(scope = this)
+
+        val result1 = tested.complete()
+        val result2 = tested.complete()
+        val result3 = tested.complete()
+
+        assertEquals(listOf(INITIAL_STATE), result1)
+        assertEquals(listOf(INITIAL_STATE), result2)
+        assertEquals(listOf(INITIAL_STATE), result3)
+    }
+
+    @Test
+    fun `returns list with states when states where emitted before flow was completed`() = runTest(dispatcher) {
+        val flow = MutableSharedFlow<String>()
+        val tested = flow.collect(scope = this)
+
+        flow.emit(INITIAL_STATE)
+        flow.emit(NEW_STATE)
+
+        assertEquals(listOf(INITIAL_STATE, NEW_STATE), tested.complete())
+    }
+
+    @Test
+    fun `returns empty list when states where emitted after flow was completed`() = runTest(dispatcher) {
+        val flow = MutableSharedFlow<String>()
+        val tested = flow.collect(scope = this)
+
+        tested.complete()
+        flow.emit(INITIAL_STATE)
+        flow.emit(NEW_STATE)
+
+        assertEquals(emptyList(), tested.complete())
+    }
+
+    private companion object {
+        const val INITIAL_STATE = "initialState"
+        const val NEW_STATE = "newValue"
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/MviViewModelTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/MviViewModelTest.kt
@@ -1,0 +1,89 @@
+package kmp.template.foundation.mvi
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kmp.template.foundation.flow.CompletableFlow.Companion.collect
+import kmp.template.foundation.mvi.config.MviConfig
+import kmp.template.foundation.mvi.config.MviDefaultConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MviViewModelTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private val config: MviConfig = MviDefaultConfig(launchDispatcher = dispatcher)
+
+    private val tested: MviContainer<String> = MviViewModel(
+        initialState = INITIAL_STATE,
+        config = config
+    )
+
+    @Test
+    fun `verify initial state of viewState when container is initialised`() {
+        assertEquals(INITIAL_STATE, tested.viewState.value)
+    }
+
+    @Test
+    fun `mute exception thrown from launch function when launch method is triggered`() = runTest {
+        tested.launch { throw Exception() }
+    }
+
+    @Test
+    fun `provide initialState when transform method is triggered for the first time`() = runTest {
+        tested.transform { this.also { assertEquals(INITIAL_STATE, this) } }
+    }
+
+    @Test
+    fun `update viewState when transform method is triggered with given value`() = runTest {
+        val givenValue = NEW_VALUE
+
+        tested.transform { givenValue }
+
+        assertEquals(NEW_VALUE, tested.viewState.value)
+    }
+
+    @Test
+    fun `collect view state when transform function is triggered`() = runTest(dispatcher) {
+        val viewState = tested.viewState.collect(this)
+
+        tested.transform { NEW_VALUE }
+
+        assertEquals(listOf(INITIAL_STATE, NEW_VALUE), viewState.complete())
+    }
+
+    @Test
+    fun `collect sideEffect when emit side effect function is triggered`() = runTest(dispatcher) {
+        val sideEffect = tested.sideEffect.collect(this)
+
+        tested.emitSideEffect(NEW_VALUE)
+
+        assertEquals(listOf(NEW_VALUE), sideEffect.complete())
+    }
+
+    @Test
+    fun `collect sideEffect emitted before subscription`() = runTest(dispatcher) {
+        tested.emitSideEffect(NEW_VALUE)
+
+        val sideEffect = tested.sideEffect.collect(this)
+
+        assertEquals(listOf(NEW_VALUE), sideEffect.complete())
+    }
+
+    @Test
+    fun `collect multiple sideEffects in order`() = runTest(dispatcher) {
+        val sideEffect = tested.sideEffect.collect(this)
+
+        tested.emitSideEffect("first")
+        tested.emitSideEffect("second")
+
+        assertEquals(listOf("first", "second"), sideEffect.complete())
+    }
+
+    private companion object {
+        const val INITIAL_STATE = "initialState"
+        const val NEW_VALUE = "newValue"
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/MviDefaultConfigTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/MviDefaultConfigTest.kt
@@ -1,0 +1,21 @@
+package kmp.template.foundation.mvi.config
+
+import kmp.template.foundation.mvi.config.dispatcher.MviDispatcher
+import kmp.template.foundation.mvi.config.exception.MviExceptionHandler
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MviDefaultConfigTest {
+
+    private val tested: MviConfig = MviDefaultConfig()
+
+    @Test
+    fun `verify default coroutines exception handler`() {
+        assertEquals(MviExceptionHandler::class, tested.exceptionHandler::class)
+    }
+
+    @Test
+    fun `verify default launch dispatcher`() {
+        assertEquals(MviDispatcher.main, tested.launchDispatcher)
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/MviTestConfigTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/MviTestConfigTest.kt
@@ -1,0 +1,26 @@
+package kmp.template.foundation.mvi.config
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kmp.template.foundation.mvi.config.exception.MviTestExceptionHandler
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MviTestConfigTest {
+
+    private val testCoroutineDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+
+    private val tested: MviConfig = MviTestConfig(testCoroutineDispatcher)
+
+    @Test
+    fun `verify test coroutines exception handler`() {
+        assertEquals(MviTestExceptionHandler::class, tested.exceptionHandler::class)
+    }
+
+    @Test
+    fun `verify test launch dispatcher`() {
+        assertEquals(testCoroutineDispatcher, tested.launchDispatcher)
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/exception/MviExceptionHandlerTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/exception/MviExceptionHandlerTest.kt
@@ -1,0 +1,19 @@
+package kmp.template.foundation.mvi.config.exception
+
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+
+class MviExceptionHandlerTest {
+
+    private val tested = MviExceptionHandler()
+
+    @Test
+    fun `does not throw provided exception when handleException is called`() {
+        val exception = IllegalArgumentException("boom")
+
+        tested.handleException(
+            context = EmptyCoroutineContext,
+            exception = exception
+        )
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/exception/MviTestExceptionHandlerTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/mvi/config/exception/MviTestExceptionHandlerTest.kt
@@ -1,0 +1,22 @@
+package kmp.template.foundation.mvi.config.exception
+
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MviTestExceptionHandlerTest {
+
+    private val tested = MviTestExceptionHandler()
+
+    @Test
+    fun `rethrows provided exception when handleException is called`() {
+        val exception = IllegalStateException("expected")
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            tested.handleException(EmptyCoroutineContext, exception)
+        }
+
+        assertEquals(exception, thrown)
+    }
+}

--- a/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/usecase/UseCaseTest.kt
+++ b/module/library/foundation/src/commonTest/kotlin/kmp/template/foundation/usecase/UseCaseTest.kt
@@ -1,0 +1,26 @@
+package kmp.template.foundation.usecase
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class UseCaseTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun `trigger invoke operator with input when use case is called`() = runTest(dispatcher) {
+        val givenUseCase = EchoUseCase()
+
+        val result = givenUseCase("World")
+
+        assertEquals("Hello World", result)
+    }
+
+    private class EchoUseCase : UseCase<String, String> {
+        override suspend fun invoke(input: String): String = "Hello $input"
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,5 +20,6 @@ rootProject.name = "kmp-template"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
-    ":app"
+    ":app",
+    ":module:library:foundation"
 )


### PR DESCRIPTION
Introduces the `foundation` library module which provides core components for building features using the MVI (Model-View-Intent) architecture.

This includes:
- `MviContainer` interface and `MviViewModel` base class.
- Configuration options for dispatchers and exception handling (`MviConfig`, `MviDefaultConfig`, `MviTestConfig`).
- A `CompletableFlow` utility for testing Kotlin Flows.
- A base `UseCase` interface.