### PR TITLE
feat: add network module with basic Ktor integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
+            implementation(projects.module.library.network)
 
             implementation(libs.bundles.compose)
             implementation(libs.koin.compose)

--- a/app/src/commonMain/kotlin/kmp/template/app/di/DiModules.kt
+++ b/app/src/commonMain/kotlin/kmp/template/app/di/DiModules.kt
@@ -1,5 +1,6 @@
 package kmp.template.app.di
 
+import kmp.template.network.di.networkModule
 import org.koin.core.module.Module
 
 internal expect val appModule: Module
@@ -8,6 +9,7 @@ internal val featureModules: List<Module> = listOf(
 )
 
 internal val libraryModules: List<Module> = listOf(
+    networkModule
 )
 
 internal val serviceModules: List<Module> = listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.gradleBuildConfig) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinSerialization) apply false
+    alias(libs.plugins.kotlinxAtomicFu) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,11 @@ java = "17"
 kermit = "2.0.8"
 koin = "4.1.1"
 kotlin = "2.2.21"
+kotlinx-atomic = "0.29.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
+ktor = "3.3.3"
 
 [libraries]
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -49,6 +51,16 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
+# Ktor
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-wasm = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
 # Gradle-config
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -77,3 +89,4 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 gradleBuildConfig = { id = "gradleBuildConfigPlugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinxAtomicFu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomic" }

--- a/module/library/network/build.gradle.kts
+++ b/module/library/network/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.gradleBuildConfig)
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinxAtomicFu)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kermit)
+            implementation(libs.koin.core)
+
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.logging)
+            implementation(libs.ktor.serialization.json)
+        }
+        commonTest.dependencies {
+            implementation(libs.bundles.unitTest)
+        }
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
+        }
+        jvmMain.dependencies {
+            implementation(libs.ktor.client.cio)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.wasm)
+        }
+    }
+}
+
+android {
+    namespace = "kmp.template.network"
+}

--- a/module/library/network/src/androidMain/AndroidManifest.xml
+++ b/module/library/network/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+</manifest>

--- a/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientCache.kt
+++ b/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientCache.kt
@@ -1,0 +1,25 @@
+package kmp.template.network.client
+
+import io.ktor.client.HttpClient
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+internal object HttpClientCache {
+
+    private val clients = HashMap<String, HttpClient>()
+    private val lock = SynchronizedObject()
+
+    fun getOrCreate(baseUrl: String): HttpClient =
+        synchronized(lock) {
+            clients.getOrPut(baseUrl) {
+                HttpClientFactory.create(baseUrl)
+            }
+        }
+
+    fun closeAllClients() {
+        synchronized(lock) {
+            clients.values.forEach { it.close() }
+            clients.clear()
+        }
+    }
+}

--- a/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientFactory.kt
+++ b/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientFactory.kt
@@ -1,0 +1,44 @@
+package kmp.template.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.http.Url
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+internal object HttpClientFactory {
+
+    private const val DEFAULT_TIMEOUT = 30_000L
+
+    fun create(baseUrl: String) = HttpClient {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    useAlternativeNames = false
+                }
+            )
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = DEFAULT_TIMEOUT
+            connectTimeoutMillis = DEFAULT_TIMEOUT
+            socketTimeoutMillis = DEFAULT_TIMEOUT
+        }
+        install(Logging) {
+            level = LogLevel.INFO
+            logger = HttpClientLogger()
+        }
+        defaultRequest {
+            val base = Url(baseUrl)
+            url {
+                protocol = base.protocol
+                host = base.host
+                port = base.port
+            }
+        }
+    }
+}

--- a/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientLogger.kt
+++ b/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientLogger.kt
@@ -1,0 +1,15 @@
+package kmp.template.network.client
+
+import io.ktor.client.plugins.logging.Logger
+import co.touchlab.kermit.Logger.Companion as KermitLogger
+
+internal class HttpClientLogger : Logger {
+
+    override fun log(message: String) {
+        KermitLogger.d(tag = TAG, messageString = message)
+    }
+
+    private companion object Companion {
+        const val TAG = "Network"
+    }
+}

--- a/module/library/network/src/commonMain/kotlin/kmp/template/network/di/NetworkModule.kt
+++ b/module/library/network/src/commonMain/kotlin/kmp/template/network/di/NetworkModule.kt
@@ -1,0 +1,10 @@
+package kmp.template.network.di
+
+import kmp.template.network.client.HttpClientCache
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val networkModule: Module = module {
+
+    factory { (baseUrl: String) -> HttpClientCache.getOrCreate(baseUrl) }
+}

--- a/module/library/network/src/commonTest/kotlin/kmp/template/network/HttpClientCacheTest.kt
+++ b/module/library/network/src/commonTest/kotlin/kmp/template/network/HttpClientCacheTest.kt
@@ -1,0 +1,38 @@
+package kmp.template.network
+
+import kmp.template.network.client.HttpClientCache
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class HttpClientCacheTest {
+
+    private val tested = HttpClientCache
+
+    @AfterTest
+    fun tearDown() {
+        tested.closeAllClients()
+    }
+
+    @Test
+    fun `provides the same instance of HttpClient for the same host name`() {
+        val host = "api.example.com"
+
+        val client1 = tested.getOrCreate(host)
+        val client2 = tested.getOrCreate(host)
+
+        assertSame(expected = client1, actual = client2)
+    }
+
+    @Test
+    fun `provides different instances of HttpClient for the different host name`() {
+        val hostA = "api.example.com"
+        val hostB = "auth.example.com"
+
+        val clientA = tested.getOrCreate(hostA)
+        val clientB = tested.getOrCreate(hostB)
+
+        assertNotSame(illegal = clientA, actual = clientB)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,5 +22,6 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(
     ":app",
     ":module:library:environment",
-    ":module:library:foundation"
+    ":module:library:foundation",
+    ":module:library:network"
 )


### PR DESCRIPTION
- Introduce a new `:module:library:network` for handling network operations.
- Integrate Ktor for multiplatform HTTP client functionality.
- Configure Ktor client with JSON serialization, logging, and default timeouts.
- Set up dependency injection for the network module using Koin.
- Add necessary Android permissions for internet access.