### PR TITLE
feat: add base design system module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.module.library.design)
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
             implementation(projects.module.library.network)
@@ -49,6 +50,17 @@ android {
         getByName("release") {
             isMinifyEnabled = false
         }
+    }
+    lint {
+        abortOnError = true
+        checkAllWarnings = true
+        checkDependencies = true
+        checkReleaseBuilds = false
+        ignoreTestSources = true
+        warningsAsErrors = false
+        disable += listOf(
+            "InvalidPackage"
+        )
     }
     dependencies {
         debugImplementation(libs.compose.ui.tooling)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ android-sdk-target = "36"
 androidx-activity-compose = "1.12.1"
 androidx-lifecycle = "2.9.6"
 compose = "1.9.3"
-compose-icons = "1.7.3"
 compose-material3 = "1.9.0"
 java = "17"
 kermit = "2.0.8"
@@ -32,7 +31,6 @@ compose-animation = { module = "org.jetbrains.compose.animation:animation", vers
 compose-components-preview = { module = "org.jetbrains.compose.components:components-ui-tooling-preview", version.ref = "compose" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
-compose-material-icons = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "compose-icons" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
@@ -71,7 +69,6 @@ compose = [
     "compose-components-preview",
     "compose-components-resources",
     "compose-foundation",
-    "compose-material-icons",
     "compose-material3",
     "compose-runtime",
     "compose-ui"

--- a/module/library/design/build.gradle.kts
+++ b/module/library/design/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.gradleBuildConfig)
+    alias(libs.plugins.kotlinMultiplatform)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.bundles.compose)
+        }
+    }
+}
+
+android {
+    namespace = "kmp.template.design"
+
+    dependencies {
+        debugImplementation(libs.compose.ui.tooling)
+    }
+}

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_arrow_back.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_arrow_back.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M640,880 L240,480l400,-400 71,71 -329,329 329,329 -71,71Z" />
+</vector>

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_cancel_circle.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_cancel_circle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="m336,680 l144,-144 144,144 56,-56 -144,-144 144,-144 -56,-56 -144,144 -144,-144 -56,56 144,144 -144,144 56,56ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z" />
+</vector>

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_check_circle.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_check_circle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="m424,664 l282,-282 -56,-56 -226,226 -114,-114 -56,56 170,170ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z" />
+</vector>

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_error_circle.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_error_circle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M480,680q17,0 28.5,-11.5T520,640q0,-17 -11.5,-28.5T480,600q-17,0 -28.5,11.5T440,640q0,17 11.5,28.5T480,680ZM440,520h80v-240h-80v240ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z" />
+</vector>

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_home.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_home.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M240,760h120v-240h240v240h120v-360L480,220 240,400v360ZM160,840v-480l320,-240 320,240v480L520,840v-240h-80v240L160,840ZM480,490Z" />
+</vector>

--- a/module/library/design/src/commonMain/composeResources/drawable/ic_info_circle.xml
+++ b/module/library/design/src/commonMain/composeResources/drawable/ic_info_circle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#000000"
+        android:pathData="M440,680h80v-240h-80v240ZM480,360q17,0 28.5,-11.5T520,320q0,-17 -11.5,-28.5T480,280q-17,0 -28.5,11.5T440,320q0,17 11.5,28.5T480,360ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z" />
+</vector>

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/annotation/ComponentPreview.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/annotation/ComponentPreview.kt
@@ -1,0 +1,9 @@
+package kmp.template.design.annotation
+
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "component",
+    group = "components"
+)
+annotation class ComponentPreview

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/annotation/ScreenPreview.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/annotation/ScreenPreview.kt
@@ -1,0 +1,17 @@
+package kmp.template.design.annotation
+
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "1. Portrait mode",
+    showBackground = true,
+    widthDp = 340,
+    heightDp = 720
+)
+@Preview(
+    name = "2. Landscape mode",
+    showBackground = true,
+    widthDp = 720,
+    heightDp = 340
+)
+annotation class ScreenPreview

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppButton.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppButton.kt
@@ -1,0 +1,131 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.component.base.ButtonType.Filled
+import kmp.template.design.component.base.ButtonType.Outlined
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContainerAlpha
+import kmp.template.design.theme.disableContentAlpha
+
+@Composable
+fun AppButton(
+    label: String,
+    onClick: () -> Unit,
+    type: ButtonType = Filled,
+    iconStart: @Composable (() -> Unit)? = null,
+    iconEnd: @Composable (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) = Button(
+    onClick = onClick,
+    modifier = modifier.defaultMinSize(
+        minHeight = AppTheme.dimensions.clickable
+    ),
+    enabled = enabled,
+    elevation = null,
+    interactionSource = null,
+    shape = AppTheme.shapes.button,
+    colors = when (type) {
+        Filled -> AppButtonDefaults.getFilledColors()
+        Outlined -> AppButtonDefaults.getOutlinedColors()
+    },
+    border = when (type) {
+        Filled -> AppButtonDefaults.getFilledBorder()
+        Outlined -> AppButtonDefaults.getOutlinedBorder(enabled)
+    },
+    contentPadding = PaddingValues(
+        horizontal = AppTheme.dimensions.large,
+        vertical = AppTheme.dimensions.small
+    ),
+    content = {
+        iconStart?.let { icon ->
+            icon()
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            text = label,
+            style = AppTheme.typography.button
+        )
+        iconEnd?.let { icon ->
+            Spacer(modifier = Modifier.width(8.dp))
+            icon()
+        }
+    }
+)
+
+enum class ButtonType {
+    Filled, Outlined
+}
+
+private object AppButtonDefaults {
+
+    @Composable
+    fun getFilledColors() = ButtonDefaults.buttonColors(
+        containerColor = AppTheme.colors.secondary,
+        contentColor = AppTheme.colors.onSecondary,
+        disabledContainerColor = AppTheme.colors.onSurface.disableContainerAlpha(),
+        disabledContentColor = AppTheme.colors.onSurface.disableContentAlpha()
+    )
+
+    @Composable
+    fun getOutlinedColors() = ButtonDefaults.outlinedButtonColors(
+        containerColor = Color.Transparent,
+        contentColor = AppTheme.colors.secondary,
+        disabledContainerColor = Color.Transparent,
+        disabledContentColor = AppTheme.colors.onSurface.disableContentAlpha()
+    )
+
+    @Composable
+    fun getFilledBorder() = null
+
+    @Composable
+    fun getOutlinedBorder(enabled: Boolean) = BorderStroke(
+        width = 1.dp,
+        color = when (enabled) {
+            true -> AppTheme.colors.secondary
+            false -> AppTheme.colors.onSurface.disableContainerAlpha()
+        }
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun ButtonPreview() = AppTheme {
+    Column {
+        AppButton(
+            label = "App Button",
+            type = Filled,
+            onClick = {}
+        )
+        AppButton(
+            label = "App Button",
+            type = Filled,
+            enabled = false,
+            onClick = {}
+        )
+        AppButton(
+            label = "App Button",
+            type = Outlined,
+            onClick = {}
+        )
+        AppButton(
+            label = "App Button",
+            type = Outlined,
+            enabled = false,
+            onClick = {}
+        )
+    }
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppCard.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppCard.kt
@@ -1,0 +1,52 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContainerAlpha
+import kmp.template.design.theme.disableContentAlpha
+
+@Composable
+fun AppCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) = Card(
+    modifier = modifier,
+    shape = AppTheme.shapes.card,
+    colors = CardDefaults.cardColors(
+        containerColor = AppTheme.colors.surfaceContainer,
+        contentColor = AppTheme.colors.onSurface,
+        disabledContentColor = AppTheme.colors.onSurface.disableContentAlpha(),
+        disabledContainerColor = AppTheme.colors.surface.disableContainerAlpha()
+    ),
+    elevation = CardDefaults.cardElevation(),
+    border = null
+) {
+    Column(
+        modifier = Modifier.padding(
+            paddingValues = PaddingValues(
+                horizontal = AppTheme.dimensions.medium,
+                vertical = AppTheme.dimensions.medium
+            )
+        ),
+        content = content
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun AppCardPreview() = AppTheme {
+    Column {
+        AppCard {
+            AppText(text = "App Card")
+            AppText(text = "Card Label")
+        }
+    }
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppDivider.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppDivider.kt
@@ -1,0 +1,26 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContentAlpha
+
+@Composable
+fun AppDivider(
+    verticalPadding: Dp = 0.dp
+) = HorizontalDivider(
+    modifier = Modifier.padding(vertical = verticalPadding),
+    color = AppTheme.colors.onSurface.disableContentAlpha(),
+    thickness = 1.dp
+)
+
+@ComponentPreview
+@Composable
+private fun AppDividerPreview() = AppTheme {
+    AppDivider()
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppIcon.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppIcon.kt
@@ -1,0 +1,34 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun AppIcon(
+    icon: DrawableResource,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current,
+    modifier: Modifier = Modifier
+) = Icon(
+    painter = painterResource(icon),
+    contentDescription = contentDescription,
+    tint = tint,
+    modifier = modifier
+)
+
+@ComponentPreview
+@Composable
+private fun AppIconPreview() = AppTheme {
+    AppIcon(
+        icon = AppTheme.icons.home,
+        modifier = Modifier.size(AppTheme.dimensions.clickable)
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppInput.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppInput.kt
@@ -1,0 +1,65 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContentAlpha
+
+@Composable
+fun AppInput(
+    label: String,
+    value: String,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    singleLine: Boolean = true,
+    imeAction: ImeAction = ImeAction.Unspecified,
+    keyboardType: KeyboardType = KeyboardType.Unspecified,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) = OutlinedTextField(
+    label = { Text(label) },
+    value = value,
+    enabled = enabled,
+    readOnly = readOnly,
+    singleLine = singleLine,
+    textStyle = AppTheme.typography.input,
+    shape = AppTheme.shapes.input,
+    colors = OutlinedTextFieldDefaults.colors().copy(
+        focusedTextColor = AppTheme.colors.onSurface,
+        unfocusedTextColor = AppTheme.colors.onSurface,
+        disabledTextColor = AppTheme.colors.onSurface.disableContentAlpha(),
+        errorTextColor = AppTheme.colors.onSurface,
+        focusedIndicatorColor = AppTheme.colors.secondary,
+        unfocusedLabelColor = AppTheme.colors.onSurface,
+        disabledLabelColor = AppTheme.colors.onSurface.disableContentAlpha(),
+    ),
+    keyboardOptions = KeyboardOptions(
+        imeAction = imeAction,
+        keyboardType = keyboardType
+    ),
+    keyboardActions = keyboardActions,
+    visualTransformation = visualTransformation,
+    onValueChange = onValueChange,
+    modifier = modifier
+)
+
+@ComponentPreview
+@Composable
+private fun AppInputPreview() = AppTheme {
+    AppInput(
+        label = "Label",
+        value = "12",
+        onValueChange = {}
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppProgressBar.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppProgressBar.kt
@@ -1,0 +1,31 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppProgressBar(
+    modifier: Modifier = Modifier,
+    color: Color = AppTheme.colors.secondary,
+    trackColor: Color = AppTheme.colors.surfaceContainer,
+) = LinearProgressIndicator(
+    modifier = modifier,
+    color = color,
+    trackColor = trackColor,
+    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+    gapSize = ProgressIndicatorDefaults.LinearIndicatorTrackGapSize
+)
+
+@ComponentPreview
+@Composable
+private fun AppProgressBarPreview() = AppTheme {
+    AppProgressBar(modifier = Modifier.fillMaxWidth())
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppProgressSpinner.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppProgressSpinner.kt
@@ -1,0 +1,31 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults.CircularIndeterminateStrokeCap
+import androidx.compose.material3.ProgressIndicatorDefaults.CircularStrokeWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+
+@Composable
+fun AppProgressSpinner(
+    modifier: Modifier = Modifier,
+    color: Color = AppTheme.colors.secondary,
+    trackColor: Color = AppTheme.colors.secondaryContainer
+) = CircularProgressIndicator(
+    modifier = modifier,
+    color = color,
+    trackColor = trackColor,
+    strokeWidth = CircularStrokeWidth,
+    strokeCap = CircularIndeterminateStrokeCap
+)
+
+@ComponentPreview
+@Composable
+private fun AppProgressSpinnerPreview() = AppTheme {
+    AppProgressSpinner(modifier = Modifier.size(64.dp))
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppScaffold.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppScaffold.kt
@@ -1,0 +1,78 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.component.topbar.AppTopCenterBar
+import kmp.template.design.theme.AppTheme
+
+@Composable
+fun AppScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackBarHost: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    containerColor: Color = AppTheme.colors.background,
+    contentColor: Color = AppTheme.colors.onBackground,
+    contentWindowInsets: WindowInsets = WindowInsets.systemBars,
+    content: @Composable (PaddingValues) -> Unit
+) = Scaffold(
+    modifier = modifier,
+    topBar = topBar,
+    bottomBar = bottomBar,
+    snackbarHost = snackBarHost,
+    floatingActionButton = floatingActionButton,
+    floatingActionButtonPosition = floatingActionButtonPosition,
+    containerColor = containerColor,
+    contentColor = contentColor,
+    contentWindowInsets = contentWindowInsets,
+    content = content
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun AppScaffoldPreview() = AppTheme {
+    AppScaffold(
+        topBar = {
+            AppTopCenterBar(
+                title = {
+                    AppText(
+                        text = "App Top Bar",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { }) {
+                        AppIcon(icon = AppTheme.icons.arrowBack)
+                    }
+                }
+            )
+        },
+        content = { paddingValues ->
+            AppCard(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxWidth()
+                    .padding(all = 16.dp)
+            ) {
+                AppText("App Label")
+            }
+        }
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppText.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppText.kt
@@ -1,0 +1,51 @@
+package kmp.template.design.component.base
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+
+@Composable
+fun AppText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = LocalContentColor.current,
+    textAlign: TextAlign = TextAlign.Start,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1
+) = Text(
+    text = text,
+    modifier = modifier,
+    color = color,
+    textAlign = textAlign,
+    overflow = overflow,
+    softWrap = softWrap,
+    maxLines = maxLines,
+    minLines = minLines,
+    style = style
+)
+
+@ComponentPreview
+@Composable
+private fun AppTextPreview() = AppTheme {
+    Column {
+        AppText(text = "Header", style = AppTheme.typography.header)
+        AppText(text = "Sub-header", style = AppTheme.typography.subheader)
+        AppText(text = "Body strong", style = AppTheme.typography.bodyStrong)
+        AppText(text = "Body regular", style = AppTheme.typography.bodyRegular)
+        AppText(text = "Body small", style = AppTheme.typography.bodySmall)
+        AppText(text = "Button text", style = AppTheme.typography.button)
+        AppText(text = "Input text", style = AppTheme.typography.input)
+    }
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationBar.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationBar.kt
@@ -1,0 +1,77 @@
+package kmp.template.design.component.navigation
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarDefaults
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContentAlpha
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun AppNavigationBar(
+    selectedId: Any,
+    items: List<AppNavigationUiModel>,
+    onClick: (route: Any) -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = AppTheme.colors.surface,
+    contentColor: Color = AppTheme.colors.onSurface,
+    itemColors: NavigationBarItemColors = NavigationBarItemColors(
+        selectedIconColor = AppTheme.colors.onSurface,
+        selectedTextColor = AppTheme.colors.onSurface,
+        selectedIndicatorColor = AppTheme.colors.primaryContainer,
+        unselectedIconColor = AppTheme.colors.onSurface, //onSurfaceVariant
+        unselectedTextColor = AppTheme.colors.onSurface, //onSurfaceVariant
+        disabledIconColor = AppTheme.colors.onSurface.disableContentAlpha(), //onSurfaceVariant
+        disabledTextColor = AppTheme.colors.onSurface.disableContentAlpha() //onSurfaceVariant
+    ),
+    tonalElevation: Dp = NavigationBarDefaults.Elevation,
+    windowInsets: WindowInsets = NavigationBarDefaults.windowInsets
+) {
+    NavigationBar(
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        tonalElevation = tonalElevation,
+        windowInsets = windowInsets,
+    ) {
+        items.forEach { item ->
+            NavigationBarItem(
+                icon = { Icon(painter = painterResource(item.icon), contentDescription = null) },
+                label = { Text(item.label) },
+                selected = selectedId == item.route,
+                onClick = { onClick(item.route) },
+                colors = itemColors
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun AppNavigationBarPreview() = AppTheme {
+    AppNavigationBar(
+        selectedId = "HOME",
+        items = listOf(
+            AppNavigationUiModel(
+                route = "HOME",
+                label = "Home",
+                icon = AppTheme.icons.home
+            ),
+            AppNavigationUiModel(
+                route = "ABOUT",
+                label = "About",
+                icon = AppTheme.icons.info
+            )
+        ),
+        onClick = {}
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDrawer.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDrawer.kt
@@ -1,0 +1,100 @@
+package kmp.template.design.component.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DrawerDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemColors
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.PermanentDrawerSheet
+import androidx.compose.material3.PermanentNavigationDrawer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun AppNavigationDrawer(
+    selectedId: Any,
+    items: List<AppNavigationUiModel>,
+    onClick: (route: Any) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(
+        horizontal = AppTheme.dimensions.small,
+        vertical = AppTheme.dimensions.medium
+    ),
+    containerColor: Color = AppTheme.colors.background,
+    contentColor: Color = AppTheme.colors.onBackground,
+    itemColors: NavigationDrawerItemColors = NavigationDrawerItemDefaults.colors(
+        selectedContainerColor = AppTheme.colors.primaryContainer,
+        selectedIconColor = AppTheme.colors.onPrimary,
+        selectedTextColor = AppTheme.colors.onPrimary,
+        unselectedContainerColor = Color.Transparent,
+        unselectedIconColor = AppTheme.colors.onPrimary, //onSurfaceVariant
+        unselectedTextColor = AppTheme.colors.onPrimary //onSurfaceVariant
+    ),
+    itemShape: Shape = AppTheme.shapes.button,
+    tonalElevation: Dp = DrawerDefaults.PermanentDrawerElevation,
+    windowInsets: WindowInsets = DrawerDefaults.windowInsets
+) {
+    PermanentNavigationDrawer(
+        drawerContent = {
+            PermanentDrawerSheet(
+                drawerContainerColor = containerColor,
+                drawerContentColor = contentColor,
+                drawerTonalElevation = tonalElevation,
+                windowInsets = windowInsets,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(contentPadding)
+            ) {
+                items.forEach { item ->
+                    NavigationDrawerItem(
+                        icon = { Icon(painter = painterResource(item.icon), contentDescription = null) },
+                        label = { Text(item.label) },
+                        selected = item.route == selectedId,
+                        onClick = { onClick(item.route) },
+                        modifier = Modifier.padding(horizontal = AppTheme.dimensions.small),
+                        colors = itemColors,
+                        shape = itemShape
+                    )
+                }
+            }
+        },
+        modifier = modifier,
+        content = {}
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun AppNavigationDrawerPreview() = AppTheme {
+    AppNavigationDrawer(
+        selectedId = "HOME",
+        items = listOf(
+            AppNavigationUiModel(
+                route = "HOME",
+                label = "Home",
+                icon = AppTheme.icons.home
+            ),
+            AppNavigationUiModel(
+                route = "ABOUT",
+                label = "About",
+                icon = AppTheme.icons.info
+            )
+        ),
+        onClick = {}
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDropdown.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDropdown.kt
@@ -1,0 +1,97 @@
+package kmp.template.design.component.navigation
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.theme.AppTheme
+import kmp.template.design.theme.disableContentAlpha
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun AppNavigationDropdown(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = AppTheme.colors.surface, //surfaceContainer
+    containerShape: Shape = AppTheme.shapes.dropdown,
+    content: @Composable ColumnScope.() -> Unit
+) = DropdownMenu(
+    expanded = expanded,
+    onDismissRequest = onDismiss,
+    modifier = modifier,
+    offset = DpOffset(0.dp, 0.dp),
+    containerColor = containerColor,
+    shape = containerShape,
+    tonalElevation = MenuDefaults.TonalElevation,
+    shadowElevation = MenuDefaults.ShadowElevation,
+    border = null,
+    content = content
+)
+
+@Composable
+fun AppNavigationDropdownItem(
+    label: String,
+    icon: DrawableResource,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(
+        horizontal = AppTheme.dimensions.medium,
+        vertical = AppTheme.dimensions.extraSmall
+    )
+) = DropdownMenuItem(
+    text = { Text(text = label) },
+    leadingIcon = { Icon(painter = painterResource(icon), contentDescription = null) },
+    trailingIcon = null,
+    modifier = modifier,
+    onClick = onClick,
+    enabled = true,
+    interactionSource = null,
+    colors = AppNavigationDropdownDefaults.getDropdownItemColors(),
+    contentPadding = contentPadding
+)
+
+private object AppNavigationDropdownDefaults {
+
+    @Composable
+    fun getDropdownItemColors() = MenuItemColors(
+        textColor = AppTheme.colors.onSurface,
+        leadingIconColor = AppTheme.colors.onSurface, //onSurfaceVariant
+        trailingIconColor = AppTheme.colors.onSurface, //onSurfaceVariant
+        disabledTextColor = AppTheme.colors.onSurface.disableContentAlpha(),
+        disabledLeadingIconColor = AppTheme.colors.onSurface.disableContentAlpha(),
+        disabledTrailingIconColor = AppTheme.colors.onSurface.disableContentAlpha()
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun AppNavigationDropdownPreview() = AppTheme {
+    AppNavigationDropdown(
+        expanded = true,
+        onDismiss = {}
+    ) {
+        AppNavigationDropdownItem(
+            label = "Home",
+            icon = AppTheme.icons.home,
+            onClick = {}
+        )
+        AppNavigationDropdownItem(
+            label = "About",
+            icon = AppTheme.icons.info,
+            onClick = {}
+        )
+    }
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationUiModel.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationUiModel.kt
@@ -1,0 +1,9 @@
+package kmp.template.design.component.navigation
+
+import org.jetbrains.compose.resources.DrawableResource
+
+data class AppNavigationUiModel(
+    val route: Any,
+    val label: String,
+    val icon: DrawableResource
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateContent.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateContent.kt
@@ -1,0 +1,229 @@
+package kmp.template.design.component.screenstate
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppButton
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppProgressSpinner
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.base.ButtonType
+import kmp.template.design.component.screenstate.ScreenStateUiModel.ErrorState
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+import kmp.template.design.component.screenstate.ScreenStateUiModel.SuccessState
+import kmp.template.design.theme.AppTheme
+import org.jetbrains.compose.resources.DrawableResource
+
+@Composable
+fun ScreenStateContent(
+    screenState: ScreenStateUiModel,
+    modifier: Modifier = Modifier,
+    successCustomIcon: DrawableResource? = null,
+    errorCustomIcon: DrawableResource? = null,
+    onFilledButtonClick: () -> Unit = {},
+    onOutlineButtonClick: () -> Unit = {}
+) = AnimatedContent(
+    targetState = screenState,
+    modifier = modifier
+) { state ->
+    when (state) {
+        is Loading -> LoadingScreenState(
+            header = state.header,
+            message = state.message,
+            filledButtonText = state.filledButtonText,
+            outlineButtonText = state.outlineButtonText,
+            onFilledButtonClick = onFilledButtonClick,
+            onOutlineButtonClick = onOutlineButtonClick,
+            modifier = Modifier.fillMaxSize()
+        )
+        is SuccessState -> SuccessScreenState(
+            header = state.header,
+            message = state.message,
+            customIcon = successCustomIcon,
+            filledButtonText = state.filledButtonText,
+            outlineButtonText = state.outlineButtonText,
+            onFilledButtonClick = onFilledButtonClick,
+            onOutlineButtonClick = onOutlineButtonClick,
+            modifier = Modifier.fillMaxSize()
+        )
+        is ErrorState -> ErrorScreenState(
+            header = state.header,
+            message = state.message,
+            customIcon = errorCustomIcon,
+            filledButtonText = state.filledButtonText,
+            outlineButtonText = state.outlineButtonText,
+            onFilledButtonClick = onFilledButtonClick,
+            onOutlineButtonClick = onOutlineButtonClick,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Composable
+private fun LoadingScreenState(
+    header: String,
+    message: String,
+    modifier: Modifier,
+    filledButtonText: String,
+    outlineButtonText: String,
+    onFilledButtonClick: () -> Unit,
+    onOutlineButtonClick: () -> Unit
+) = ScreenStateCommonContent(
+    header = header,
+    message = message,
+    modifier = modifier,
+    filledButtonText = filledButtonText,
+    outlineButtonText = outlineButtonText,
+    onFilledButtonClick = onFilledButtonClick,
+    onOutlineButtonClick = onOutlineButtonClick
+) {
+    AppProgressSpinner(
+        modifier = Modifier.size(64.dp)
+    )
+}
+
+@Composable
+private fun SuccessScreenState(
+    header: String,
+    message: String,
+    customIcon: DrawableResource?,
+    filledButtonText: String,
+    outlineButtonText: String,
+    onFilledButtonClick: () -> Unit,
+    onOutlineButtonClick: () -> Unit,
+    modifier: Modifier
+) = ScreenStateCommonContent(
+    header = header,
+    message = message,
+    modifier = modifier,
+    filledButtonText = filledButtonText,
+    outlineButtonText = outlineButtonText,
+    onFilledButtonClick = onFilledButtonClick,
+    onOutlineButtonClick = onOutlineButtonClick
+) {
+    AppIcon(
+        icon = customIcon ?: AppTheme.icons.check,
+        modifier = Modifier.size(64.dp)
+    )
+}
+
+@Composable
+private fun ErrorScreenState(
+    header: String,
+    message: String,
+    customIcon: DrawableResource?,
+    filledButtonText: String,
+    outlineButtonText: String,
+    onFilledButtonClick: () -> Unit,
+    onOutlineButtonClick: () -> Unit,
+    modifier: Modifier
+) = ScreenStateCommonContent(
+    header = header,
+    message = message,
+    modifier = modifier,
+    filledButtonText = filledButtonText,
+    outlineButtonText = outlineButtonText,
+    onFilledButtonClick = onFilledButtonClick,
+    onOutlineButtonClick = onOutlineButtonClick
+) {
+    AppIcon(
+        icon = customIcon ?: AppTheme.icons.error,
+        tint = AppTheme.colors.error,
+        modifier = Modifier.size(64.dp)
+    )
+}
+
+@Composable
+private fun ScreenStateCommonContent(
+    header: String,
+    message: String,
+    modifier: Modifier,
+    filledButtonText: String,
+    outlineButtonText: String,
+    onFilledButtonClick: () -> Unit,
+    onOutlineButtonClick: () -> Unit,
+    customContent: @Composable ColumnScope.() -> Unit
+) = Box(
+    contentAlignment = Alignment.Center,
+    modifier = modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(AppTheme.dimensions.small)
+    ) {
+        customContent()
+
+        Spacer(modifier = Modifier.height(AppTheme.dimensions.medium))
+        if (header.isNotEmpty()) {
+            AppText(
+                text = header,
+                style = AppTheme.typography.header
+            )
+        }
+        if (message.isNotEmpty()) {
+            AppText(
+                text = message,
+                style = AppTheme.typography.bodyRegular
+            )
+        }
+
+        Spacer(modifier = Modifier.height(AppTheme.dimensions.large))
+        if (filledButtonText.isNotEmpty()) {
+            AppButton(
+                label = filledButtonText,
+                type = ButtonType.Filled,
+                onClick = onFilledButtonClick
+            )
+        }
+        if (outlineButtonText.isNotEmpty()) {
+            AppButton(
+                label = outlineButtonText,
+                type = ButtonType.Outlined,
+                onClick = onOutlineButtonClick
+            )
+        }
+    }
+}
+
+@ScreenPreview
+@Composable
+private fun LoadingScreenStatePreview() = AppTheme {
+    ScreenStateContent(
+        screenState = Loading()
+    )
+}
+
+@ScreenPreview
+@Composable
+private fun SuccessScreenStatePreview() = AppTheme {
+    ScreenStateContent(
+        screenState = SuccessState(
+            header = "Hurray!",
+            message = "Success message",
+            filledButtonText = "Home Screen"
+        )
+    )
+}
+
+@ScreenPreview
+@Composable
+private fun ErrorScreenStatePreview() = AppTheme {
+    ScreenStateContent(
+        screenState = ErrorState(
+            message = "Something went wrong :(",
+            filledButtonText = "Refresh",
+            outlineButtonText = "Cancel"
+        )
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateUiModel.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateUiModel.kt
@@ -1,0 +1,36 @@
+package kmp.template.design.component.screenstate
+
+import androidx.compose.runtime.Stable
+
+@Stable
+sealed class ScreenStateUiModel {
+
+    abstract val header: String
+    abstract val message: String
+    abstract val filledButtonText: String
+    abstract val outlineButtonText: String
+
+    @Stable
+    data class Loading(
+        override val header: String = "",
+        override val message: String = "",
+        override val filledButtonText: String = "",
+        override val outlineButtonText: String = ""
+    ) : ScreenStateUiModel()
+
+    @Stable
+    data class SuccessState(
+        override val header: String = "",
+        override val message: String = "",
+        override val filledButtonText: String = "",
+        override val outlineButtonText: String = ""
+    ) : ScreenStateUiModel()
+
+    @Stable
+    data class ErrorState(
+        override val header: String = "",
+        override val message: String = "",
+        override val filledButtonText: String = "",
+        override val outlineButtonText: String = ""
+    ) : ScreenStateUiModel()
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/topbar/AppTopCenterBar.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/topbar/AppTopCenterBar.kt
@@ -1,0 +1,66 @@
+package kmp.template.design.component.topbar
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppText
+import kmp.template.design.theme.AppTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopCenterBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    expandedHeight: Dp = TopAppBarDefaults.TopAppBarExpandedHeight,
+    scrollBehavior: TopAppBarScrollBehavior? = null
+) = CenterAlignedTopAppBar(
+    title = title,
+    modifier = modifier,
+    navigationIcon = navigationIcon,
+    actions = actions,
+    windowInsets = windowInsets,
+    expandedHeight = expandedHeight,
+    scrollBehavior = scrollBehavior,
+    colors = TopAppBarColors(
+        containerColor = AppTheme.colors.primary,
+        scrolledContainerColor = AppTheme.colors.primaryVariant,
+        navigationIconContentColor = AppTheme.colors.onPrimary,
+        titleContentColor = AppTheme.colors.onPrimary,
+        subtitleContentColor = AppTheme.colors.onPrimary,
+        actionIconContentColor = AppTheme.colors.onPrimary
+    )
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun AppTopCenterBarPreview() = AppTheme {
+    AppTopCenterBar(
+        title = {
+            AppText(
+                text = "Center Text",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = { }) {
+                AppIcon(icon = AppTheme.icons.arrowBack)
+            }
+        }
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/topbar/AppTopStartBar.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/topbar/AppTopStartBar.kt
@@ -1,0 +1,65 @@
+package kmp.template.design.component.topbar
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import kmp.template.design.annotation.ComponentPreview
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppText
+import kmp.template.design.theme.AppTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopStartBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+    expandedHeight: Dp = TopAppBarDefaults.TopAppBarExpandedHeight,
+    scrollBehavior: TopAppBarScrollBehavior? = null
+) = TopAppBar(
+    title = title,
+    modifier = modifier,
+    navigationIcon = navigationIcon,
+    actions = actions,
+    windowInsets = windowInsets,
+    expandedHeight = expandedHeight,
+    scrollBehavior = scrollBehavior,
+    colors = TopAppBarDefaults.topAppBarColors(
+        containerColor = AppTheme.colors.primary,
+        scrolledContainerColor = AppTheme.colors.primaryVariant,
+        navigationIconContentColor = AppTheme.colors.onPrimary,
+        titleContentColor = AppTheme.colors.onPrimary,
+        subtitleContentColor = AppTheme.colors.onPrimary,
+        actionIconContentColor = AppTheme.colors.onPrimary
+    )
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun AppTopStartBarPreview() = AppTheme {
+    AppTopStartBar(
+        title = {
+            AppText(
+                text = "Start Text",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = { }) {
+                AppIcon(icon = AppTheme.icons.arrowBack)
+            }
+        }
+    )
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppColorPalette.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppColorPalette.kt
@@ -1,0 +1,28 @@
+package kmp.template.design.theme
+
+import androidx.compose.ui.graphics.Color
+
+internal object AppColorPalette {
+
+    // content
+    val tealDark = Color(0xFF013287)
+    val tealLight = Color(0xFF4B40E0)
+    val violetDark = Color(0xFF5D3573)
+    val violetLight = Color(0xFFAD6EBE)
+
+    // surface
+    val black = Color(0xFF121212)
+    val grayDark = Color(0xFF424242)
+    val grayLight = Color(0x56ECEFF1)
+    val white = Color(0xFFFFFFFF)
+
+    // error
+    val redDark = Color(0xFFB00020)
+    val redLight = Color(0xFFDE283A)
+}
+
+internal fun Color.colorVariantAlpha() = copy(alpha = 0.70f)
+internal fun Color.colorContainerAlpha() = copy(alpha = 0.45f)
+
+internal fun Color.disableContainerAlpha() = copy(alpha = 0.12f)
+internal fun Color.disableContentAlpha() = copy(alpha = 0.38f)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppColorScheme.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppColorScheme.kt
@@ -1,0 +1,68 @@
+package kmp.template.design.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+internal val LocalColors = staticCompositionLocalOf { lightColorScheme() }
+
+@Immutable
+data class AppColorScheme(
+    val primary: Color,
+    val primaryVariant: Color,
+    val primaryContainer: Color,
+    val secondary: Color,
+    val secondaryVariant: Color,
+    val secondaryContainer: Color,
+    val background: Color,
+    val surface: Color,
+    val surfaceVariant: Color,
+    val surfaceContainer: Color,
+    val error: Color,
+    val onPrimary: Color,
+    val onSecondary: Color,
+    val onBackground: Color,
+    val onSurface: Color,
+    val onError: Color,
+    val isDarkMode: Boolean
+)
+
+internal fun lightColorScheme() = AppColorScheme(
+    primary = AppColorPalette.tealLight,
+    primaryVariant = AppColorPalette.tealLight.colorVariantAlpha(),
+    primaryContainer = AppColorPalette.tealLight.colorContainerAlpha(),
+    secondary = AppColorPalette.violetLight,
+    secondaryVariant = AppColorPalette.violetLight.colorVariantAlpha(),
+    secondaryContainer = AppColorPalette.violetLight.colorContainerAlpha(),
+    background = AppColorPalette.white,
+    surface = AppColorPalette.grayLight,
+    surfaceVariant = AppColorPalette.grayLight.colorVariantAlpha(),
+    surfaceContainer = AppColorPalette.grayLight.colorContainerAlpha(),
+    error = AppColorPalette.redLight,
+    onPrimary = AppColorPalette.black,
+    onSecondary = AppColorPalette.white,
+    onBackground = AppColorPalette.black,
+    onSurface = AppColorPalette.black,
+    onError = AppColorPalette.white,
+    isDarkMode = false
+)
+
+internal fun darkColorScheme() = AppColorScheme(
+    primary = AppColorPalette.tealDark,
+    primaryVariant = AppColorPalette.tealDark.colorVariantAlpha(),
+    primaryContainer = AppColorPalette.tealDark.colorContainerAlpha(),
+    secondary = AppColorPalette.violetDark,
+    secondaryVariant = AppColorPalette.violetDark.colorVariantAlpha(),
+    secondaryContainer = AppColorPalette.violetDark.colorContainerAlpha(),
+    background = AppColorPalette.black,
+    surface = AppColorPalette.grayDark,
+    surfaceVariant = AppColorPalette.grayDark.colorVariantAlpha(),
+    surfaceContainer = AppColorPalette.grayDark.colorContainerAlpha(),
+    error = AppColorPalette.redDark,
+    onPrimary = AppColorPalette.white,
+    onSecondary = AppColorPalette.white,
+    onBackground = AppColorPalette.white,
+    onSurface = AppColorPalette.white,
+    onError = AppColorPalette.white,
+    isDarkMode = true
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppDimensions.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppDimensions.kt
@@ -1,0 +1,19 @@
+package kmp.template.design.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal val LocalDimensions = staticCompositionLocalOf { AppDimensions() }
+
+@Immutable
+data class AppDimensions(
+    val extraSmall: Dp = 4.dp,
+    val small: Dp = 8.dp,
+    val medium: Dp = 16.dp,
+    val large: Dp = 24.dp,
+    val extraLarge: Dp = 32.dp,
+
+    val clickable: Dp = 48.dp
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppIcons.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppIcons.kt
@@ -1,0 +1,24 @@
+package kmp.template.design.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import kmp_template.module.library.design.generated.resources.Res
+import kmp_template.module.library.design.generated.resources.ic_arrow_back
+import kmp_template.module.library.design.generated.resources.ic_cancel_circle
+import kmp_template.module.library.design.generated.resources.ic_check_circle
+import kmp_template.module.library.design.generated.resources.ic_error_circle
+import kmp_template.module.library.design.generated.resources.ic_home
+import kmp_template.module.library.design.generated.resources.ic_info_circle
+import org.jetbrains.compose.resources.DrawableResource
+
+internal val LocalIcons = staticCompositionLocalOf { AppIcons() }
+
+@Immutable
+data class AppIcons(
+    val arrowBack: DrawableResource = Res.drawable.ic_arrow_back,
+    val cancel: DrawableResource = Res.drawable.ic_cancel_circle,
+    val check: DrawableResource = Res.drawable.ic_check_circle,
+    val error: DrawableResource = Res.drawable.ic_error_circle,
+    val home: DrawableResource = Res.drawable.ic_home,
+    val info: DrawableResource = Res.drawable.ic_info_circle
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppShapes.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppShapes.kt
@@ -1,0 +1,18 @@
+package kmp.template.design.theme
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.dp
+
+internal val LocalShapes = staticCompositionLocalOf { AppShapes() }
+
+@Immutable
+data class AppShapes(
+    val surface: CornerBasedShape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
+    val dropdown: CornerBasedShape = RoundedCornerShape(8.dp),
+    val card: CornerBasedShape = RoundedCornerShape(8.dp),
+    val button: CornerBasedShape = RoundedCornerShape(8.dp),
+    val input: CornerBasedShape = RoundedCornerShape(8.dp)
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppTheme.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppTheme.kt
@@ -1,0 +1,71 @@
+package kmp.template.design.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+
+object AppTheme {
+
+    val colors: AppColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalColors.current
+
+    val dimensions: AppDimensions
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalDimensions.current
+
+    val icons: AppIcons
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalIcons.current
+
+    val shapes: AppShapes
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalShapes.current
+
+    val typography: AppTypography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalTypography.current
+}
+
+@Composable
+fun AppTheme(
+    isDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) = InternalAppTheme(
+    colors = if (isDarkTheme) darkColorScheme() else lightColorScheme(),
+    content = content
+)
+
+@Composable
+private fun InternalAppTheme(
+    colors: AppColorScheme = AppTheme.colors,
+    dimensions: AppDimensions = AppTheme.dimensions,
+    icons: AppIcons = AppTheme.icons,
+    shapes: AppShapes = AppTheme.shapes,
+    typography: AppTypography = AppTheme.typography,
+    content: @Composable () -> Unit
+) = CompositionLocalProvider(
+    LocalColors provides colors,
+    LocalDimensions provides dimensions,
+    LocalIcons provides icons,
+    LocalShapes provides shapes,
+    LocalTypography provides typography
+) {
+    Surface(
+        color = AppTheme.colors.background,
+        contentColor = AppTheme.colors.onBackground
+    ) {
+        ProvideTextStyle(
+            value = typography.bodyRegular,
+            content = content
+        )
+    }
+}

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppTypography.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/theme/AppTypography.kt
@@ -1,0 +1,66 @@
+package kmp.template.design.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.LineHeightStyle.Alignment
+import androidx.compose.ui.text.style.LineHeightStyle.Trim
+import androidx.compose.ui.unit.sp
+
+internal val LocalTypography = staticCompositionLocalOf { AppTypography() }
+
+@Immutable
+data class AppTypography(
+    val header: TextStyle = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 24.sp,
+        letterSpacing = 0.sp,
+        lineHeight = 32.sp,
+        lineHeightStyle = LineHeightStyle(
+            alignment = Alignment.Center,
+            trim = Trim.None
+        )
+    ),
+    val subheader: TextStyle = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        letterSpacing = 0.15.sp,
+        lineHeight = 28.sp,
+        lineHeightStyle = LineHeightStyle(
+            alignment = Alignment.Center,
+            trim = Trim.None
+        )
+    ),
+    val bodyRegular: TextStyle = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        letterSpacing = 0.4.sp,
+        lineHeight = 24.sp
+    ),
+    val bodyStrong: TextStyle = TextStyle(
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        letterSpacing = 0.4.sp,
+        lineHeight = 24.sp
+    ),
+    val bodySmall: TextStyle = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        letterSpacing = 0.25.sp,
+        lineHeight = 16.sp
+    ),
+    val button: TextStyle = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        letterSpacing = 1.25.sp,
+        lineHeight = 24.sp
+    ),
+    val input: TextStyle = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        letterSpacing = 0.5.sp,
+        lineHeight = 24.sp
+    )
+)

--- a/module/library/foundation/build.gradle.kts
+++ b/module/library/foundation/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.gradleBuildConfig)
     alias(libs.plugins.kotlinMultiplatform)
 }
@@ -7,6 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(libs.androidx.lifecycle.runtime)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.kermit)
             implementation(libs.kotlinx.coroutines.core)

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/lifecycle/SideEffectDispatcher.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/lifecycle/SideEffectDispatcher.kt
@@ -1,0 +1,27 @@
+package kmp.template.foundation.lifecycle
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun <UiAction> SideEffectDispatcher(
+    eventsFlow: Flow<UiAction>,
+    onEvent: suspend (UiAction) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnEvent by rememberUpdatedState(newValue = onEvent)
+
+    LaunchedEffect(eventsFlow) {
+        lifecycleOwner.repeatOnLifecycle(STARTED) {
+            eventsFlow.collect { event ->
+                currentOnEvent(event)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
     ":app",
+    ":module:library:design",
     ":module:library:environment",
     ":module:library:foundation",
     ":module:library:network"


### PR DESCRIPTION
This commit introduces the `design` library module, which will contain the application's design system.

Key additions include:
- Theme: is established, defining color schemes, typography, shapes, dimensions, and icons.
- Base Components: a set of fundamental, reusable UI components are created: `AppButton`, `AppCard`, `AppScaffold`, `AppText`, `AppInput`, `AppIcon`, `AppDivider`, `AppProgressBar`, and `AppProgressSpinner`.
- Navigation Components: UI components for navigation are added, including `AppNavigationBar`, `AppNavigationDrawer`, and `AppNavigationDropdown`.
- Top App Bars: `AppTopCenterBar` and `AppTopStartBar` are introduced.
- Screen State: A `ScreenStateContent` composable is added to handle loading, success, and error UI states.
- Icons: A set of vector drawable icons are included.
- Preview Annotations: Custom annotations are created for standardized component previews.