### PR TITLE
feat: implement navigation based on Navigation 3 library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinSerialization) apply false
     alias(libs.plugins.kotlinxAtomicFu) apply false
+    alias(libs.plugins.mokkery) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,9 @@ android-gradle-plugin = "8.13.2"
 android-sdk-compile = "36"
 android-sdk-min = "26"
 android-sdk-target = "36"
-androidx-activity-compose = "1.12.1"
-androidx-lifecycle = "2.9.6"
+androidx-activity-compose = "1.12.2"
+androidx-lifecycle = "2.10.0-alpha07"
+androidx-navigation3 = "1.1.0-alpha01"
 compose = "1.9.3"
 compose-material3 = "1.9.0"
 java = "17"
@@ -13,9 +14,9 @@ koin = "4.1.1"
 kotlin = "2.2.21"
 kotlinx-atomic = "0.29.0"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
 ktor = "3.3.3"
+mokkery = "3.0.0"
 
 [libraries]
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -23,8 +24,10 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 
 # AndroidX
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
+androidx-lifecycle-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+androidx-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
 
 # Compose
 compose-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose" }
@@ -46,8 +49,6 @@ koin-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
-kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Ktor
@@ -74,6 +75,15 @@ compose = [
     "compose-runtime",
     "compose-ui"
 ]
+lifecycle = [
+    "androidx-lifecycle-runtime",
+    "androidx-lifecycle-viewmodel"
+]
+navigation = [
+    "androidx-lifecycle-navigation3",
+    "androidx-navigation3-ui",
+    "kotlinx-serialization-json"
+]
 unitTest = [
     "kotlin-test",
     "kotlinx-coroutines-test"
@@ -88,3 +98,4 @@ gradleBuildConfig = { id = "gradleBuildConfigPlugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinxAtomicFu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomic" }
+mokkery = { id = "dev.mokkery", version.ref = "mokkery" }

--- a/module/feature/sample/build.gradle.kts
+++ b/module/feature/sample/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.gradleBuildConfig)
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 kotlin {
@@ -12,11 +13,11 @@ kotlin {
             implementation(projects.module.library.design)
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
-
-            implementation(libs.androidx.lifecycle.runtime)
-            implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(projects.module.library.navigation)
 
             implementation(libs.bundles.compose)
+            implementation(libs.bundles.lifecycle)
+            implementation(libs.bundles.navigation)
             implementation(libs.koin.compose)
             implementation(libs.koin.viewmodel)
 

--- a/module/feature/sample/src/commonMain/composeResources/values/strings.xml
+++ b/module/feature/sample/src/commonMain/composeResources/values/strings.xml
@@ -1,10 +1,30 @@
 <resources>
-    <string name="sample_screen_header">Kotlin Multiplatform Project</string>
+    <string name="sample_navigation_bar_home">Home</string>
+    <string name="sample_navigation_bar_about">About</string>
+
+    <string name="sample_home_screen_header">KMP Template</string>
+    <string name="sample_home_card_header">Features</string>
+    <string name="sample_home_card_design_label">Design System</string>
+    <string name="sample_home_card_environment_label">Environment</string>
+
+    <string name="sample_design_screen_header">Sample Design System</string>
+    <string name="sample_design_fonts_card_header">Fonts</string>
+    <string name="sample_design_icons_card_header">Icons</string>
+    <string name="sample_design_buttons_card_header">Buttons</string>
+    <string name="sample_design_inputs_card_header">Inputs</string>
+    <string name="sample_design_progress_card_header">Progress</string>
+    <string name="sample_design_spacers_card_header">Spacers</string>
 
     <string name="sample_environment_screen_header">Environment</string>
+    <string name="sample_environment_card_header">Platform Information</string>
     <string name="sample_environment_name_label">Platform type: %1$s</string>
     <string name="sample_environment_app_id_label">Application id: %1$s</string>
     <string name="sample_environment_version_label">Version name: %1$s</string>
     <string name="sample_environment_debug_label">Debug build: %1$s</string>
+
+    <string name="sample_about_screen_header">About Template</string>
+    <string name="sample_about_card_header">KMP Project</string>
+    <string name="sample_about_card_info_message">Kotlin multiplatform template with gradle multimodule architecture.</string>
+    <string name="sample_about_card_support_message">Supported targets:</string>
 
 </resources>

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
@@ -1,6 +1,10 @@
 package kmp.template.feature.sample.di
 
 import kmp.template.feature.sample.presentation.SampleViewModel
+import kmp.template.feature.sample.presentation.about.SampleAboutViewModel
+import kmp.template.feature.sample.presentation.design.SampleDesignViewModel
+import kmp.template.feature.sample.presentation.environment.SampleEnvironmentViewModel
+import kmp.template.feature.sample.presentation.home.SampleHomeViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -8,5 +12,9 @@ import org.koin.dsl.module
 val sampleModule: Module = module {
 
     // ViewModels
+    viewModelOf(::SampleAboutViewModel)
+    viewModelOf(::SampleDesignViewModel)
+    viewModelOf(::SampleEnvironmentViewModel)
+    viewModelOf(::SampleHomeViewModel)
     viewModelOf(::SampleViewModel)
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
@@ -1,0 +1,20 @@
+package kmp.template.feature.sample.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal sealed interface SampleRoute : NavKey {
+
+    @Serializable
+    data object HomeDestination : SampleRoute
+
+    @Serializable
+    data object SampleDesignDestination : SampleRoute
+
+    @Serializable
+    data object SampleEnvironmentDestination : SampleRoute
+
+    @Serializable
+    data object AboutDestination : SampleRoute
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleIntent.kt
@@ -1,6 +1,0 @@
-package kmp.template.feature.sample.presentation
-
-internal sealed interface SampleIntent {
-
-    data object EnvironmentPressed : SampleIntent
-}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
@@ -1,44 +1,38 @@
 package kmp.template.feature.sample.presentation
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
 import kmp.template.design.annotation.ScreenPreview
-import kmp.template.design.component.base.AppButtonRow
-import kmp.template.design.component.base.AppCard
-import kmp.template.design.component.base.AppComponentSpacer
-import kmp.template.design.component.base.AppDisplayTextStyle
-import kmp.template.design.component.base.AppDivider
-import kmp.template.design.component.base.AppFilledButton
-import kmp.template.design.component.base.AppFilledIconButton
-import kmp.template.design.component.base.AppIcon
-import kmp.template.design.component.base.AppItemSpacer
-import kmp.template.design.component.base.AppOutlinedButton
-import kmp.template.design.component.base.AppOutlinedIconButton
-import kmp.template.design.component.base.AppOutlinedInput
-import kmp.template.design.component.base.AppProgressBar
-import kmp.template.design.component.base.AppProgressSpinner
-import kmp.template.design.component.base.AppScaffold
-import kmp.template.design.component.base.AppSectionSpacer
-import kmp.template.design.component.base.AppText
-import kmp.template.design.component.base.AppTitleTextStyle
+import kmp.template.design.component.navigation.AppNavigationBar
+import kmp.template.design.component.navigation.AppNavigationUiModel
 import kmp.template.design.theme.AppTheme
-import kmp.template.feature.sample.presentation.SampleIntent.EnvironmentPressed
+import kmp.template.feature.sample.navigation.SampleRoute.AboutDestination
+import kmp.template.feature.sample.navigation.SampleRoute.HomeDestination
+import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
+import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.presentation.about.SampleAboutScreen
+import kmp.template.feature.sample.presentation.design.SampleDesignScreen
+import kmp.template.feature.sample.presentation.environment.SampleEnvironmentScreen
+import kmp.template.feature.sample.presentation.home.SampleHomeScreen
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.compose.NavigatorDisplay
+import kmp.template.navigation.compose.NavigatorTabController
+import kmp.template.navigation.compose.navigatorPreview
+import kmp.template.navigation.compose.rememberNavigator
 import kmp_template.module.feature.sample.generated.resources.Res
-import kmp_template.module.feature.sample.generated.resources.sample_environment_app_id_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_debug_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_name_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_screen_header
-import kmp_template.module.feature.sample.generated.resources.sample_environment_version_label
-import kmp_template.module.feature.sample.generated.resources.sample_screen_header
+import kmp_template.module.feature.sample.generated.resources.sample_navigation_bar_about
+import kmp_template.module.feature.sample.generated.resources.sample_navigation_bar_home
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -48,205 +42,113 @@ fun SampleScreen() {
     val viewModel: SampleViewModel = koinViewModel()
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
 
+    val navigator: Navigator = rememberNavigator(
+        initialRoute = HomeDestination,
+        serializers = SerializersModule {
+            polymorphic(NavKey::class) {
+                subclass(subclass = SampleDesignDestination::class, serializer = SampleDesignDestination.serializer())
+                subclass(subclass = SampleEnvironmentDestination::class, serializer = SampleEnvironmentDestination.serializer())
+                subclass(subclass = HomeDestination::class, serializer = HomeDestination.serializer())
+                subclass(subclass = AboutDestination::class, serializer = AboutDestination.serializer())
+            }
+        }
+    )
+
+    val navEntryProvider: (key: NavKey) -> NavEntry<NavKey> = remember(navigator) {
+        entryProvider {
+            entry<HomeDestination> {
+                SampleHomeScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+            entry<SampleDesignDestination> {
+                SampleDesignScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+            entry<SampleEnvironmentDestination> {
+                SampleEnvironmentScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+            entry<AboutDestination> {
+                SampleAboutScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+        }
+    }
+
     SampleScreen(
         viewState = viewState,
-        intent = viewModel::processIntent
+        navigator = navigator,
+        content = {
+            NavigatorDisplay(
+                navigator = navigator,
+                entryProvider = navEntryProvider,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
     )
 }
 
 @Composable
-internal fun SampleScreen(
+private fun SampleScreen(
     viewState: SampleViewState,
-    intent: (SampleIntent) -> Unit
-) = AppScaffold { paddingValues ->
-    Column(
-        verticalArrangement = Arrangement.spacedBy(AppTheme.dimensions.spaceMd),
-        modifier = Modifier
-            .padding(paddingValues)
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-            .padding(horizontal = AppTheme.dimensions.spaceMd)
+    navigator: Navigator,
+    content: @Composable () -> Unit
+) = Column {
+    AnimatedVisibility(
+        visible = viewState.screenReady,
+        modifier = Modifier.weight(1f)
     ) {
-        AppCard(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            AppTitleTextStyle {
-                AppText(stringResource(Res.string.sample_screen_header))
-                AppComponentSpacer()
-            }
+        content()
+    }
+    SampleNavigationBar(
+        navigator = navigator
+    )
+}
 
-            AppText(stringResource(Res.string.sample_environment_name_label, viewState.environmentName))
-            AppText(stringResource(Res.string.sample_environment_app_id_label, viewState.applicationId))
-            AppText(stringResource(Res.string.sample_environment_version_label, viewState.versionName))
-            AppText(stringResource(Res.string.sample_environment_debug_label, viewState.debugLabel))
-            AppComponentSpacer()
+@Composable
+private fun SampleNavigationBar(
+    navigator: Navigator
+) {
+    val navigationTabs = listOf(
+        AppNavigationUiModel(
+            id = HomeDestination,
+            label = stringResource(Res.string.sample_navigation_bar_home),
+            icon = AppTheme.icons.home
+        ),
+        AppNavigationUiModel(
+            id = AboutDestination,
+            label = stringResource(Res.string.sample_navigation_bar_about),
+            icon = AppTheme.icons.infoCircle
+        )
+    )
 
-            AppFilledButton(
-                label = stringResource(Res.string.sample_environment_screen_header),
-                onClick = { intent(EnvironmentPressed) }
-            )
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Basic Design System")
-            }
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Fonts")
-                AppDivider()
-            }
-            AppText(text = "Text format: display", style = AppTheme.typography.display)
-            AppText(text = "Text format: headline", style = AppTheme.typography.headline)
-            AppText(text = "Text format: title", style = AppTheme.typography.title)
-            AppText(text = "Text format: body medium", style = AppTheme.typography.bodyMedium)
-            AppText(text = "Text format: body small", style = AppTheme.typography.bodySmall)
-            AppText(text = "Text format: button", style = AppTheme.typography.button)
-            AppText(text = "Text format: input", style = AppTheme.typography.input)
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Icons")
-                AppDivider()
-            }
-            AppButtonRow {
-                AppIcon(icon = AppTheme.icons.home)
-                AppIcon(icon = AppTheme.icons.arrowForward)
-                AppIcon(icon = AppTheme.icons.arrowBack)
-                AppIcon(icon = AppTheme.icons.expandMore)
-                AppIcon(icon = AppTheme.icons.expandLess)
-                AppIcon(icon = AppTheme.icons.accountCircle)
-                AppIcon(icon = AppTheme.icons.infoCircle)
-                AppIcon(icon = AppTheme.icons.checkCircle)
-                AppIcon(icon = AppTheme.icons.errorCircle)
-            }
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Buttons")
-                AppDivider()
-            }
-            AppButtonRow {
-                AppFilledButton(
-                    label = "Button",
-                    onClick = {}
-                )
-                AppFilledButton(
-                    label = "Button",
-                    enabled = false,
-                    onClick = {}
-                )
-                AppFilledIconButton(
-                    icon = AppTheme.icons.accountCircle,
-                    onClick = {}
-                )
-            }
-            AppButtonRow {
-                AppOutlinedButton(
-                    label = "Button",
-                    onClick = {}
-                )
-                AppOutlinedButton(
-                    label = "Button",
-                    enabled = false,
-                    onClick = {}
-                )
-                AppOutlinedIconButton(
-                    icon = AppTheme.icons.accountCircle,
-                    onClick = {}
-                )
-            }
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Inputs")
-                AppDivider()
-            }
-            AppOutlinedInput(
-                label = "Empty input",
-                value = "",
-                onValueChange = {}
-            )
-            AppOutlinedInput(
-                label = "Fulfill input",
-                value = "600 500 400",
-                onValueChange = {},
-                prefix = { AppText(text = "+48") },
-                suffix = { AppText(text = "PL") },
-            )
-            AppOutlinedInput(
-                label = "Disabled input",
-                value = "",
-                enabled = false,
-                onValueChange = {}
-            )
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Progress")
-                AppDivider()
-            }
-
-            AppProgressBar()
-            AppProgressBar(progress = 0.00f)
-            AppProgressBar(progress = 0.25f)
-            AppProgressBar(progress = 0.50f)
-            AppProgressBar(progress = 1.00f)
-
-            AppButtonRow {
-                AppProgressSpinner()
-                AppProgressSpinner(progress = 0.00f)
-                AppProgressSpinner(progress = 0.25f)
-                AppProgressSpinner(progress = 0.50f)
-                AppProgressSpinner(progress = 1.00f)
-            }
-        }
-
-        AppCard(
-            modifier = Modifier.fillMaxWidth(),
-            itemPadding = AppTheme.dimensions.spaceMd
-        ) {
-            AppDisplayTextStyle {
-                AppText(text = "Spacers")
-                AppDivider()
-            }
-            AppButtonRow {
-                AppSectionSpacer(modifier = Modifier.background(AppTheme.colors.primary))
-                AppComponentSpacer(modifier = Modifier.background(AppTheme.colors.secondary))
-                AppItemSpacer(modifier = Modifier.background(AppTheme.colors.error))
-            }
-        }
+    NavigatorTabController(
+        navigator = navigator,
+        tabDestinations = navigationTabs.map { it.id },
+        startDestination = HomeDestination
+    ) {
+        AppNavigationBar(
+            selectedId = it,
+            items = navigationTabs,
+            onSelected = ::navigateToNavigationBar
+        )
     }
 }
 
 @ScreenPreview
 @Composable
-private fun SampleScreenPreview() = AppTheme {
+private fun ScreenPreview() = AppTheme {
     SampleScreen(
         viewState = SampleViewState(),
-        intent = {}
+        navigator = navigatorPreview(HomeDestination),
+        content = {}
     )
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleViewModel.kt
@@ -1,33 +1,5 @@
 package kmp.template.feature.sample.presentation
 
-import kmp.template.environment.Environment
-import kmp.template.feature.sample.presentation.SampleIntent.EnvironmentPressed
 import kmp.template.foundation.mvi.MviViewModel
 
-internal class SampleViewModel(
-    private val environment: Environment
-) : MviViewModel<SampleViewState>(SampleViewState()) {
-
-    init {
-        initViewState()
-    }
-
-    private fun initViewState() = transform {
-        copy(
-            environmentName = environment.type.name,
-            applicationId = environment.applicationId,
-            versionName = environment.versionName + " (" + environment.versionCode + ")",
-            debugLabel = environment.debug.toString()
-        )
-    }
-
-    fun processIntent(intent: SampleIntent) {
-        when (intent) {
-            is EnvironmentPressed -> onEnvironmentPressed()
-        }
-    }
-
-    private fun onEnvironmentPressed() {
-        // it will be implemented with navigation feature
-    }
-}
+internal class SampleViewModel : MviViewModel<SampleViewState>(SampleViewState())

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleViewState.kt
@@ -1,8 +1,5 @@
 package kmp.template.feature.sample.presentation
 
 internal data class SampleViewState(
-    val environmentName: String = "",
-    val applicationId: String = "",
-    val versionName: String = "",
-    val debugLabel: String = ""
+    val screenReady: Boolean = true
 )

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutScreen.kt
@@ -1,0 +1,119 @@
+package kmp.template.feature.sample.presentation.about
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppDisplayTextStyle
+import kmp.template.design.component.base.AppHeadlineTextStyle
+import kmp.template.design.component.base.AppItemSpacer
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.screenstate.ScreenStateContent
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.theme.AppTheme
+import kmp.template.environment.EnvironmentType
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.sample_about_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_about_card_info_message
+import kmp_template.module.feature.sample.generated.resources.sample_about_card_support_message
+import kmp_template.module.feature.sample.generated.resources.sample_about_screen_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun SampleAboutScreen(
+    viewModel: SampleAboutViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    SampleAboutScreen(
+        viewState = viewState
+    )
+}
+
+@Composable
+private fun SampleAboutScreen(
+    viewState: SampleAboutViewState
+) = AppScaffold { paddingValues ->
+    SampleAboutContent(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(paddingValues)
+    )
+    ScreenStateContent(
+        screenState = viewState.screenState,
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+@Composable
+private fun SampleAboutContent(
+    modifier: Modifier
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = spacedBy(AppTheme.dimensions.spaceSm),
+    contentPadding = PaddingValues(AppTheme.dimensions.spaceMd)
+) {
+    item { SampleAboutHeader() }
+    item { SampleAboutCard() }
+}
+
+@Composable
+private fun SampleAboutHeader() = Box(
+    contentAlignment = Alignment.Center,
+    modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = AppTheme.dimensions.spaceMd)
+) {
+    AppDisplayTextStyle {
+        AppText(stringResource(Res.string.sample_about_screen_header))
+    }
+}
+
+@Composable
+private fun SampleAboutCard() = AppCard(
+    itemPadding = AppTheme.dimensions.spaceSm,
+    modifier = Modifier.fillMaxWidth()
+) {
+    AppHeadlineTextStyle {
+        AppText(stringResource(Res.string.sample_about_card_header))
+    }
+    AppItemSpacer()
+
+    AppText(stringResource(Res.string.sample_about_card_info_message))
+    AppText(stringResource(Res.string.sample_about_card_support_message))
+
+    EnvironmentType.entries.forEach { type ->
+        AppText("-> ${type.name}")
+    }
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    SampleAboutScreen(
+        viewState = SampleAboutViewState(
+            screenState = ScreenStateUiModel.Content
+        )
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutViewModel.kt
@@ -1,0 +1,15 @@
+package kmp.template.feature.sample.presentation.about
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.foundation.mvi.MviViewModel
+
+internal class SampleAboutViewModel : MviViewModel<SampleAboutViewState>(SampleAboutViewState()) {
+
+    init {
+        initViewState()
+    }
+
+    private fun initViewState() = transform {
+        copy(screenState = ScreenStateUiModel.Content)
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/about/SampleAboutViewState.kt
@@ -1,0 +1,8 @@
+package kmp.template.feature.sample.presentation.about
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+
+internal data class SampleAboutViewState(
+    val screenState: ScreenStateUiModel = Loading()
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignIntent.kt
@@ -1,0 +1,6 @@
+package kmp.template.feature.sample.presentation.design
+
+internal sealed interface SampleDesignIntent {
+
+    data object NavigateBackPressed : SampleDesignIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignScreen.kt
@@ -1,0 +1,276 @@
+package kmp.template.feature.sample.presentation.design
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppButtonRow
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppComponentSpacer
+import kmp.template.design.component.base.AppDisplayTextStyle
+import kmp.template.design.component.base.AppDivider
+import kmp.template.design.component.base.AppFilledButton
+import kmp.template.design.component.base.AppFilledIconButton
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppItemSpacer
+import kmp.template.design.component.base.AppOutlinedButton
+import kmp.template.design.component.base.AppOutlinedIconButton
+import kmp.template.design.component.base.AppOutlinedInput
+import kmp.template.design.component.base.AppProgressBar
+import kmp.template.design.component.base.AppProgressSpinner
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppSectionSpacer
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.screenstate.ScreenStateContent
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.topbar.AppTopCenterBar
+import kmp.template.design.theme.AppTheme
+import kmp.template.feature.sample.presentation.design.SampleDesignIntent.NavigateBackPressed
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.sample_design_buttons_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_fonts_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_icons_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_inputs_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_progress_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_screen_header
+import kmp_template.module.feature.sample.generated.resources.sample_design_spacers_card_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun SampleDesignScreen(
+    viewModel: SampleDesignViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    SampleDesignScreen(
+        viewState = viewState,
+        intent = viewModel::processIntent
+    )
+}
+
+@Composable
+private fun SampleDesignScreen(
+    viewState: SampleDesignViewState,
+    intent: (SampleDesignIntent) -> Unit
+) = AppScaffold(
+    topBar = {
+        SampleDesignTopBar(
+            intent = intent
+        )
+    },
+    content = { contentPadding ->
+        SampleDesignContent(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = contentPadding.calculateTopPadding())
+        )
+        ScreenStateContent(
+            screenState = viewState.screenState,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SampleDesignTopBar(
+    intent: (SampleDesignIntent) -> Unit
+) = AppTopCenterBar(
+    title = {
+        AppText(text = stringResource(Res.string.sample_design_screen_header))
+    },
+    navigationIcon = {
+        IconButton(onClick = { intent(NavigateBackPressed) }) {
+            AppIcon(icon = AppTheme.icons.arrowBack)
+        }
+    }
+)
+
+@Composable
+private fun SampleDesignContent(
+    modifier: Modifier,
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(
+        space = AppTheme.dimensions.spaceSm
+    ),
+    contentPadding = PaddingValues(
+        horizontal = AppTheme.dimensions.spaceMd,
+        vertical = AppTheme.dimensions.spaceSm
+    )
+) {
+    item { SampleDesignTypography() }
+    item { SampleDesignIcons() }
+    item { SampleDesignButtons() }
+    item { SampleDesignInputs() }
+    item { SampleDesignProgress() }
+    item { SampleDesignSpacers() }
+}
+
+@Composable
+private fun SampleDesignTypography() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_fonts_card_header)
+) {
+    AppText(text = "Text format: display", style = AppTheme.typography.display)
+    AppText(text = "Text format: headline", style = AppTheme.typography.headline)
+    AppText(text = "Text format: title", style = AppTheme.typography.title)
+    AppText(text = "Text format: body medium", style = AppTheme.typography.bodyMedium)
+    AppText(text = "Text format: body small", style = AppTheme.typography.bodySmall)
+    AppText(text = "Text format: button", style = AppTheme.typography.button)
+    AppText(text = "Text format: input", style = AppTheme.typography.input)
+}
+
+@Composable
+private fun SampleDesignIcons() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_icons_card_header)
+) {
+    AppButtonRow(horizontalAlignment = Alignment.Start) {
+        AppIcon(icon = AppTheme.icons.home)
+        AppIcon(icon = AppTheme.icons.arrowForward)
+        AppIcon(icon = AppTheme.icons.arrowBack)
+        AppIcon(icon = AppTheme.icons.expandMore)
+        AppIcon(icon = AppTheme.icons.expandLess)
+        AppIcon(icon = AppTheme.icons.accountCircle)
+        AppIcon(icon = AppTheme.icons.infoCircle)
+        AppIcon(icon = AppTheme.icons.checkCircle)
+        AppIcon(icon = AppTheme.icons.errorCircle)
+    }
+}
+
+@Composable
+private fun SampleDesignButtons() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_buttons_card_header)
+) {
+    AppButtonRow(horizontalAlignment = Alignment.Start) {
+        AppFilledButton(
+            label = "Button",
+            onClick = {}
+        )
+        AppFilledButton(
+            label = "Button",
+            enabled = false,
+            onClick = {}
+        )
+        AppFilledIconButton(
+            icon = AppTheme.icons.accountCircle,
+            onClick = {}
+        )
+    }
+    AppButtonRow(horizontalAlignment = Alignment.Start) {
+        AppOutlinedButton(
+            label = "Button",
+            onClick = {}
+        )
+        AppOutlinedButton(
+            label = "Button",
+            enabled = false,
+            onClick = {}
+        )
+        AppOutlinedIconButton(
+            icon = AppTheme.icons.accountCircle,
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+private fun SampleDesignInputs() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_inputs_card_header)
+) {
+    AppOutlinedInput(
+        label = "Empty input",
+        value = "",
+        onValueChange = {}
+    )
+    AppOutlinedInput(
+        label = "Fulfill input",
+        value = "600 500 400",
+        onValueChange = {},
+        prefix = { AppText(text = "+48") },
+        suffix = { AppText(text = "PL") },
+    )
+    AppOutlinedInput(
+        label = "Disabled input",
+        value = "",
+        enabled = false,
+        onValueChange = {}
+    )
+}
+
+@Composable
+private fun SampleDesignProgress() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_progress_card_header)
+) {
+    AppProgressBar()
+    AppProgressBar(progress = 0.00f)
+    AppProgressBar(progress = 0.25f)
+    AppProgressBar(progress = 0.50f)
+    AppProgressBar(progress = 1.00f)
+
+    AppButtonRow(horizontalAlignment = Alignment.Start) {
+        AppProgressSpinner()
+        AppProgressSpinner(progress = 0.00f)
+        AppProgressSpinner(progress = 0.25f)
+        AppProgressSpinner(progress = 0.50f)
+        AppProgressSpinner(progress = 1.00f)
+    }
+}
+
+@Composable
+private fun SampleDesignSpacers() = SampleDesignCardItem(
+    title = stringResource(Res.string.sample_design_spacers_card_header)
+) {
+    AppButtonRow(horizontalAlignment = Alignment.Start) {
+        AppSectionSpacer(modifier = Modifier.background(AppTheme.colors.primary))
+        AppComponentSpacer(modifier = Modifier.background(AppTheme.colors.secondary))
+        AppItemSpacer(modifier = Modifier.background(AppTheme.colors.error))
+    }
+}
+
+@Composable
+private fun SampleDesignCardItem(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit
+) = AppCard(
+    modifier = Modifier.fillMaxWidth(),
+    itemPadding = AppTheme.dimensions.spaceMd
+) {
+    AppDisplayTextStyle {
+        AppText(text = title)
+    }
+    AppDivider()
+    content(this)
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    SampleDesignScreen(
+        viewState = SampleDesignViewState(
+            screenState = ScreenStateUiModel.Content
+        ),
+        intent = {}
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignViewModel.kt
@@ -1,0 +1,27 @@
+package kmp.template.feature.sample.presentation.design
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.feature.sample.presentation.design.SampleDesignIntent.NavigateBackPressed
+import kmp.template.foundation.mvi.MviViewModel
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+
+internal class SampleDesignViewModel : MviViewModel<SampleDesignViewState>(SampleDesignViewState()) {
+
+    init {
+        initViewState()
+    }
+
+    private fun initViewState() = transform {
+        copy(screenState = ScreenStateUiModel.Content)
+    }
+
+    fun processIntent(intent: SampleDesignIntent) {
+        when (intent) {
+            is NavigateBackPressed -> onNavigateBackPressed()
+        }
+    }
+
+    private fun onNavigateBackPressed() {
+        emitSideEffect(NavigateUp())
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignViewState.kt
@@ -1,0 +1,8 @@
+package kmp.template.feature.sample.presentation.design
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+
+internal data class SampleDesignViewState(
+    val screenState: ScreenStateUiModel = Loading()
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentIntent.kt
@@ -1,0 +1,6 @@
+package kmp.template.feature.sample.presentation.environment
+
+internal sealed interface SampleEnvironmentIntent {
+
+    data object NavigateBackPressed : SampleEnvironmentIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentScreen.kt
@@ -1,0 +1,142 @@
+package kmp.template.feature.sample.presentation.environment
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppComponentSpacer
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.base.AppTitleTextStyle
+import kmp.template.design.component.topbar.AppTopCenterBar
+import kmp.template.design.theme.AppTheme
+import kmp.template.feature.sample.presentation.environment.SampleEnvironmentIntent.NavigateBackPressed
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.sample_environment_app_id_label
+import kmp_template.module.feature.sample.generated.resources.sample_environment_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_environment_debug_label
+import kmp_template.module.feature.sample.generated.resources.sample_environment_name_label
+import kmp_template.module.feature.sample.generated.resources.sample_environment_screen_header
+import kmp_template.module.feature.sample.generated.resources.sample_environment_version_label
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun SampleEnvironmentScreen(
+    viewModel: SampleEnvironmentViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    SampleEnvironmentScreen(
+        viewState = viewState,
+        intent = viewModel::processIntent
+    )
+}
+
+@Composable
+private fun SampleEnvironmentScreen(
+    viewState: SampleEnvironmentViewState,
+    intent: (SampleEnvironmentIntent) -> Unit
+) = AppScaffold(
+    topBar = {
+        SampleEnvironmentTopBar(
+            intent = intent
+        )
+    },
+    content = { contentPadding ->
+        SampleEnvironmentContent(
+            viewState = viewState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(contentPadding)
+        )
+    }
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SampleEnvironmentTopBar(
+    intent: (SampleEnvironmentIntent) -> Unit
+) = AppTopCenterBar(
+    title = {
+        AppText(text = stringResource(Res.string.sample_environment_screen_header))
+    },
+    navigationIcon = {
+        IconButton(onClick = { intent(NavigateBackPressed) }) {
+            AppIcon(icon = AppTheme.icons.arrowBack)
+        }
+    }
+)
+
+@Composable
+private fun SampleEnvironmentContent(
+    viewState: SampleEnvironmentViewState,
+    modifier: Modifier
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(
+        space = AppTheme.dimensions.spaceSm
+    ),
+    contentPadding = PaddingValues(
+        horizontal = AppTheme.dimensions.spaceMd,
+        vertical = AppTheme.dimensions.spaceSm
+    )
+) {
+    item {
+        SampleEnvironmentCard(
+            viewState = viewState,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun SampleEnvironmentCard(
+    viewState: SampleEnvironmentViewState,
+    modifier: Modifier
+) = AppCard(
+    modifier = modifier
+) {
+    AppTitleTextStyle {
+        AppText(stringResource(Res.string.sample_environment_card_header))
+    }
+    AppComponentSpacer()
+
+    AppText(stringResource(Res.string.sample_environment_name_label, viewState.environmentName))
+    AppText(stringResource(Res.string.sample_environment_app_id_label, viewState.applicationId))
+    AppText(stringResource(Res.string.sample_environment_version_label, viewState.versionName))
+    AppText(stringResource(Res.string.sample_environment_debug_label, viewState.debugLabel))
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    SampleEnvironmentScreen(
+        viewState = SampleEnvironmentViewState(
+            environmentName = "iOS",
+            applicationId = "kmp.template",
+            versionName = "1.0.0",
+            debugLabel = "1"
+        ),
+        intent = {}
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentViewModel.kt
@@ -1,0 +1,34 @@
+package kmp.template.feature.sample.presentation.environment
+
+import kmp.template.environment.Environment
+import kmp.template.feature.sample.presentation.environment.SampleEnvironmentIntent.NavigateBackPressed
+import kmp.template.foundation.mvi.MviViewModel
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+
+internal class SampleEnvironmentViewModel(
+    private val environment: Environment
+) : MviViewModel<SampleEnvironmentViewState>(SampleEnvironmentViewState()) {
+
+    init {
+        initViewState()
+    }
+
+    private fun initViewState() = transform {
+        copy(
+            environmentName = environment.type.name,
+            applicationId = environment.applicationId,
+            versionName = environment.versionName + " (" + environment.versionCode + ")",
+            debugLabel = environment.debug.toString()
+        )
+    }
+
+    fun processIntent(intent: SampleEnvironmentIntent) {
+        when (intent) {
+            is NavigateBackPressed -> onNavigateBackPressed()
+        }
+    }
+
+    private fun onNavigateBackPressed() {
+        emitSideEffect(NavigateUp())
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentViewState.kt
@@ -1,0 +1,8 @@
+package kmp.template.feature.sample.presentation.environment
+
+internal data class SampleEnvironmentViewState(
+    val environmentName: String = "",
+    val applicationId: String = "",
+    val versionName: String = "",
+    val debugLabel: String = ""
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
@@ -1,0 +1,7 @@
+package kmp.template.feature.sample.presentation.home
+
+internal sealed interface SampleHomeIntent {
+
+    data object DesignSystemPressed : SampleHomeIntent
+    data object EnvironmentPressed : SampleHomeIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
@@ -1,0 +1,134 @@
+package kmp.template.feature.sample.presentation.home
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppDisplayTextStyle
+import kmp.template.design.component.base.AppFilledButton
+import kmp.template.design.component.base.AppHeadlineTextStyle
+import kmp.template.design.component.base.AppItemSpacer
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.screenstate.ScreenStateContent
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.theme.AppTheme
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.sample_home_card_design_label
+import kmp_template.module.feature.sample.generated.resources.sample_home_card_environment_label
+import kmp_template.module.feature.sample.generated.resources.sample_home_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_home_screen_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun SampleHomeScreen(
+    viewModel: SampleHomeViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    SampleHomeScreen(
+        viewState = viewState,
+        intent = viewModel::processIntent
+    )
+}
+
+@Composable
+private fun SampleHomeScreen(
+    viewState: SampleHomeViewState,
+    intent: (SampleHomeIntent) -> Unit
+) = AppScaffold { paddingValues ->
+    SampleHomeContent(
+        intent = intent,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(paddingValues)
+    )
+    ScreenStateContent(
+        screenState = viewState.screenState,
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+@Composable
+private fun SampleHomeContent(
+    intent: (SampleHomeIntent) -> Unit,
+    modifier: Modifier
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = spacedBy(AppTheme.dimensions.spaceSm),
+    contentPadding = PaddingValues(AppTheme.dimensions.spaceMd)
+) {
+    item { SampleHomeHeader() }
+    item {
+        SampleHomeCard(
+            intent = intent
+        )
+    }
+}
+
+@Composable
+private fun SampleHomeHeader() = Box(
+    contentAlignment = Alignment.Center,
+    modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = AppTheme.dimensions.spaceMd)
+) {
+    AppDisplayTextStyle {
+        AppText(stringResource(Res.string.sample_home_screen_header))
+    }
+}
+
+@Composable
+private fun SampleHomeCard(
+    intent: (SampleHomeIntent) -> Unit
+) = AppCard(
+    itemPadding = AppTheme.dimensions.spaceSm,
+    modifier = Modifier.fillMaxWidth()
+) {
+    AppHeadlineTextStyle {
+        AppText(stringResource(Res.string.sample_home_card_header))
+    }
+    AppItemSpacer()
+
+    AppFilledButton(
+        label = stringResource(Res.string.sample_home_card_design_label),
+        onClick = { intent(DesignSystemPressed) }
+    )
+    AppFilledButton(
+        label = stringResource(Res.string.sample_home_card_environment_label),
+        onClick = { intent(EnvironmentPressed) }
+    )
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    SampleHomeScreen(
+        viewState = SampleHomeViewState(
+            screenState = ScreenStateUiModel.Content
+        ),
+        intent = {}
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
@@ -1,0 +1,35 @@
+package kmp.template.feature.sample.presentation.home
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
+import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.foundation.mvi.MviViewModel
+import kmp.template.navigation.NavigatorEvent.NavigateTo
+
+internal class SampleHomeViewModel : MviViewModel<SampleHomeViewState>(SampleHomeViewState()) {
+
+    init {
+        initViewState()
+    }
+
+    private fun initViewState() = transform {
+        copy(screenState = ScreenStateUiModel.Content)
+    }
+
+    fun processIntent(intent: SampleHomeIntent) {
+        when (intent) {
+            is DesignSystemPressed -> onDesignSystemPressed()
+            is EnvironmentPressed -> onEnvironmentPressed()
+        }
+    }
+
+    private fun onDesignSystemPressed() {
+        emitSideEffect(NavigateTo(SampleDesignDestination))
+    }
+
+    private fun onEnvironmentPressed() {
+        emitSideEffect(NavigateTo(SampleEnvironmentDestination))
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewState.kt
@@ -1,0 +1,8 @@
+package kmp.template.feature.sample.presentation.home
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+
+internal data class SampleHomeViewState(
+    val screenState: ScreenStateUiModel = Loading()
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationBar.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationBar.kt
@@ -18,7 +18,7 @@ import kmp.template.design.theme.AppTheme
 
 @Composable
 fun AppNavigationBar(
-    selectedRoute: Any,
+    selectedId: Any,
     items: List<AppNavigationUiModel>,
     onSelected: (Any) -> Unit,
     modifier: Modifier = Modifier,
@@ -47,8 +47,8 @@ fun AppNavigationBar(
             NavigationBarItem(
                 icon = { AppIcon(icon = item.icon) },
                 label = { AppText(text = item.label) },
-                selected = item.route == selectedRoute,
-                onClick = { onSelected(item.route) },
+                selected = item.id == selectedId,
+                onClick = { onSelected(item.id) },
                 colors = itemColors
             )
         }
@@ -59,15 +59,15 @@ fun AppNavigationBar(
 @Composable
 private fun AppNavigationBarPreview() = AppTheme {
     AppNavigationBar(
-        selectedRoute = "HOME",
+        selectedId = "HOME",
         items = listOf(
             AppNavigationUiModel(
-                route = "HOME",
+                id = "HOME",
                 label = "Home",
                 icon = AppTheme.icons.home
             ),
             AppNavigationUiModel(
-                route = "ABOUT",
+                id = "ABOUT",
                 label = "About",
                 icon = AppTheme.icons.infoCircle
             )

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDrawer.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDrawer.kt
@@ -24,7 +24,7 @@ import kmp.template.design.theme.AppTheme
 
 @Composable
 fun AppNavigationDrawer(
-    selectedRoute: Any,
+    selectedId: Any,
     items: List<AppNavigationUiModel>,
     onSelected: (Any) -> Unit,
     modifier: Modifier = Modifier,
@@ -64,8 +64,8 @@ fun AppNavigationDrawer(
                     NavigationDrawerItem(
                         icon = { AppIcon(icon = item.icon) },
                         label = { AppText(text = item.label) },
-                        selected = item.route == selectedRoute,
-                        onClick = { onSelected(item.route) },
+                        selected = item.id == selectedId,
+                        onClick = { onSelected(item.id) },
                         modifier = Modifier.padding(
                             horizontal = AppTheme.dimensions.spaceSm,
                             vertical = AppTheme.dimensions.spaceXs
@@ -84,15 +84,15 @@ fun AppNavigationDrawer(
 @Composable
 private fun AppNavigationDrawerPreview() = AppTheme {
     AppNavigationDrawer(
-        selectedRoute = "HOME",
+        selectedId = "HOME",
         items = listOf(
             AppNavigationUiModel(
-                route = "HOME",
+                id = "HOME",
                 label = "Home",
                 icon = AppTheme.icons.home
             ),
             AppNavigationUiModel(
-                route = "ABOUT",
+                id = "ABOUT",
                 label = "About",
                 icon = AppTheme.icons.infoCircle
             )

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDropdown.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationDropdown.kt
@@ -55,7 +55,7 @@ fun AppNavigationDropdown(
             leadingIcon = { AppIcon(icon = item.icon) },
             trailingIcon = null,
             onClick = {
-                onSelected(item.route)
+                onSelected(item.id)
                 onDismiss()
             },
             enabled = true,
@@ -73,12 +73,12 @@ private fun AppNavigationDropdownPreview() = AppTheme {
             expanded = true,
             items = listOf(
                 AppNavigationUiModel(
-                    route = "HOME",
+                    id = "HOME",
                     label = "Home",
                     icon = AppTheme.icons.home
                 ),
                 AppNavigationUiModel(
-                    route = "ABOUT",
+                    id = "ABOUT",
                     label = "About",
                     icon = AppTheme.icons.infoCircle
                 )

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationUiModel.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/navigation/AppNavigationUiModel.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 @Stable
 data class AppNavigationUiModel(
-    val route: Any,
+    val id: Any,
     val label: String,
     val icon: ImageVector
 )

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateContent.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateContent.kt
@@ -24,6 +24,7 @@ import kmp.template.design.component.base.AppSectionSpacer
 import kmp.template.design.component.base.AppText
 import kmp.template.design.component.screenstate.ScreenStateUiModel.ErrorState
 import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Content
 import kmp.template.design.component.screenstate.ScreenStateUiModel.SuccessState
 import kmp.template.design.theme.AppTheme
 
@@ -41,6 +42,7 @@ fun ScreenStateContent(
     modifier = modifier
 ) { state ->
     when (state) {
+        is Content -> {}
         is Loading -> LoadingScreenState(
             header = state.header,
             message = state.message,
@@ -204,7 +206,9 @@ private fun ScreenStateCommonContent(
 @Composable
 private fun LoadingScreenStatePreview() = AppTheme {
     ScreenStateContent(
-        screenState = Loading()
+        screenState = Loading(
+            message = "Loading..."
+        )
     )
 }
 

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateUiModel.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/screenstate/ScreenStateUiModel.kt
@@ -11,6 +11,14 @@ sealed class ScreenStateUiModel {
     abstract val outlineButtonText: String
 
     @Stable
+    data object Content : ScreenStateUiModel() {
+        override val header: String = ""
+        override val message: String = ""
+        override val filledButtonText: String = ""
+        override val outlineButtonText: String = ""
+    }
+
+    @Stable
     data class Loading(
         override val header: String = "",
         override val message: String = "",

--- a/module/library/environment/src/commonTest/kotlin/kmp/template/environment/EnvironmentTypeTest.kt
+++ b/module/library/environment/src/commonTest/kotlin/kmp/template/environment/EnvironmentTypeTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class EnvironmentTypeTest {
 
     @Test
-    fun `returns enum contains in expected order when entries is called`() {
+    fun `returns enum values in expected order when entries is called`() {
         val result = EnvironmentType.entries
 
         assertContentEquals(

--- a/module/library/environment/src/commonTest/kotlin/kmp/template/environment/NoOpEnvironmentTest.kt
+++ b/module/library/environment/src/commonTest/kotlin/kmp/template/environment/NoOpEnvironmentTest.kt
@@ -6,18 +6,19 @@ import kotlin.test.assertEquals
 class NoOpEnvironmentTest {
 
     @Test
-    fun `returns defaults values when not overridden`() {
-        val given = NoOpEnvironment(type = EnvironmentType.JVM)
+    fun `returns default values when not overwritten`() {
+        val result = NoOpEnvironment(type = EnvironmentType.JVM)
 
-        assertEquals("application", given.applicationId)
-        assertEquals("1.0.0", given.versionName)
-        assertEquals("1", given.versionCode)
-        assertEquals(false, given.debug)
+        assertEquals(EnvironmentType.JVM, result.type)
+        assertEquals("application", result.applicationId)
+        assertEquals("1.0.0", result.versionName)
+        assertEquals("1", result.versionCode)
+        assertEquals(false, result.debug)
     }
 
     @Test
     fun `returns custom values when values are provided`() {
-        val given = NoOpEnvironment(
+        val result = NoOpEnvironment(
             type = EnvironmentType.WEB,
             applicationId = "web.app",
             versionName = "2.3.4",
@@ -25,10 +26,10 @@ class NoOpEnvironmentTest {
             debug = true
         )
 
-        assertEquals(EnvironmentType.WEB, given.type)
-        assertEquals("web.app", given.applicationId)
-        assertEquals("2.3.4", given.versionName)
-        assertEquals("42", given.versionCode)
-        assertEquals(true, given.debug)
+        assertEquals(EnvironmentType.WEB, result.type)
+        assertEquals("web.app", result.applicationId)
+        assertEquals("2.3.4", result.versionName)
+        assertEquals("42", result.versionCode)
+        assertEquals(true, result.debug)
     }
 }

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/lifecycle/SideEffectDispatcher.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/lifecycle/SideEffectDispatcher.kt
@@ -2,12 +2,12 @@ package kmp.template.foundation.lifecycle
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 @Composable
 fun <UiAction> SideEffectDispatcher(
@@ -15,12 +15,11 @@ fun <UiAction> SideEffectDispatcher(
     onEvent: suspend (UiAction) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val currentOnEvent by rememberUpdatedState(newValue = onEvent)
 
-    LaunchedEffect(eventsFlow) {
+    LaunchedEffect(eventsFlow, onEvent) {
         lifecycleOwner.repeatOnLifecycle(STARTED) {
-            eventsFlow.collect { event ->
-                currentOnEvent(event)
+            withContext(Dispatchers.Main.immediate) {
+                eventsFlow.collect(onEvent)
             }
         }
     }

--- a/module/library/navigation/build.gradle.kts
+++ b/module/library/navigation/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.gradleBuildConfig)
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.mokkery)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.bundles.compose)
+            implementation(libs.bundles.navigation)
+        }
+        commonTest.dependencies {
+            implementation(libs.bundles.unitTest)
+        }
+    }
+}
+
+android {
+    namespace = "kmp.template.navigation"
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/Navigator.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/Navigator.kt
@@ -1,0 +1,20 @@
+package kmp.template.navigation
+
+import androidx.compose.runtime.Stable
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+
+/**
+ * Cross‑platform navigation facade used by UI layers to drive screen changes.
+ *
+ * Implementations are responsible for maintaining a back stack of [NavKey] entries
+ * and executing [NavigatorEvent] requests such as forward navigation, replacement,
+ * and navigating up.
+ */
+@Stable
+interface Navigator {
+
+    val backStack: NavBackStack<NavKey>
+
+    fun navigate(effect: NavigatorEvent)
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/NavigatorEvent.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/NavigatorEvent.kt
@@ -1,0 +1,38 @@
+package kmp.template.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlin.reflect.KClass
+
+/**
+ * Navigation events processed by the Navigator.
+ */
+sealed interface NavigatorEvent {
+
+    /**
+     * Navigate to a new destination.
+     * @param destination The target destination which should be navigated to.
+     * @param singleInstance If true, prevents duplicate instances of this destination in the backstack.
+     * @param clearStackTo If provided, clears the backstack up to the specified route type.
+     */
+    data class NavigateTo(
+        val destination: NavKey,
+        val singleInstance: Boolean = true,
+        val clearStackTo: KClass<*>? = null
+    ) : NavigatorEvent
+
+    /**
+     * Replace the current destination with a new one.
+     * @param destination The target destination which should replace the current one.
+     */
+    data class ReplaceTo(
+        val destination: NavKey
+    ) : NavigatorEvent
+
+    /**
+     * Navigate back in the backstack.
+     * @param clearStackTo If provided, clears the backstack up to the specified route type.
+     */
+    data class NavigateUp(
+        val clearStackTo: KClass<*>? = null
+    ) : NavigatorEvent
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorDisplay.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorDisplay.kt
@@ -1,0 +1,34 @@
+package kmp.template.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import kmp.template.navigation.Navigator
+
+/**
+ * Renders the current navigation back stack using Navigation3's [NavDisplay].
+ *
+ * Apply this composable near the root of your screen hierarchy to display
+ * destinations from [navigator]'s back stack with default decorators for
+ * saveable state and ViewModel storage.
+ */
+@Composable
+fun NavigatorDisplay(
+    navigator: Navigator,
+    entryProvider: (key: NavKey) -> NavEntry<NavKey>,
+    modifier: Modifier = Modifier
+) {
+    NavDisplay(
+        modifier = modifier,
+        backStack = navigator.backStack,
+        entryDecorators = listOf(
+            rememberSaveableStateHolderNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator()
+        ),
+        entryProvider = entryProvider
+    )
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorFactory.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorFactory.kt
@@ -1,0 +1,45 @@
+package kmp.template.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.savedstate.serialization.SavedStateConfiguration
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.internal.NavigatorController
+import kmp.template.navigation.internal.NavigatorPreview
+import kotlinx.serialization.modules.SerializersModule
+
+/**
+ * Creates and remembers a [Navigator] tied to the current Compose composition.
+ *
+ * The navigator is backed by a [NavBackStack] created with the provided
+ * [SerializersModule] to support save/restore of destinations.
+ */
+@Composable
+fun rememberNavigator(
+    initialRoute: NavKey,
+    serializers: SerializersModule
+): Navigator {
+
+    val backStack: NavBackStack<NavKey> = rememberNavBackStack(
+        configuration = SavedStateConfiguration {
+            serializersModule = serializers
+        },
+        initialRoute
+    )
+
+    val navigator: Navigator = remember(backStack) {
+        NavigatorController(backStack = backStack)
+    }
+
+    return navigator
+}
+
+/**
+ * Lightweight preview helper that returns a simple [Navigator] backed by an in‑memory
+ * back stack, useful for previews and tests where full state saving is not required.
+ */
+@Composable
+fun navigatorPreview(initialRoute: NavKey): Navigator = NavigatorPreview(initialRoute)

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorTabController.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/compose/NavigatorTabController.kt
@@ -1,0 +1,62 @@
+package kmp.template.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.navigation3.runtime.NavKey
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent.NavigateTo
+import kotlin.reflect.KClass
+
+/**
+ * Navigator tab controller for menu UI components.
+ * @param navigator The navigator class implementation (See [rememberNavigator] compose).
+ * @param tabDestinations List of tab destinations.
+ * @param startDestination The start destination for the tab bar.
+ */
+@Composable
+fun NavigatorTabController(
+    navigator: Navigator,
+    tabDestinations: List<Any>,
+    startDestination: Any,
+    content: @Composable NavigatorTabControllerScope.(selectedId: Any) -> Unit
+) {
+    val scope = remember(navigator, startDestination) {
+        NavigatorTabControllerScope(navigator, startDestination::class)
+    }
+
+    val selectedId = remember(navigator.backStack.lastOrNull(), tabDestinations) {
+        navigator.backStack.lastOrNull {
+            tabDestinations.any { route -> route == it }
+        }
+    }
+
+    scope.content(selectedId ?: startDestination)
+}
+
+/**
+ * Scope for [NavigatorTabController] composable.
+ */
+@Stable
+data class NavigatorTabControllerScope(
+    private val navigator: Navigator,
+    private val startDestination: KClass<*>
+) {
+
+    /**
+     * Default single-backstack logic for tab bar navigation.
+     */
+    @Stable
+    fun navigateToNavigationBar(id: Any) {
+        require(id is NavKey) {
+            "Unsupported type: $id - in Navigation3 destination should inherit from NavKey interface."
+        }
+        navigator.navigate(
+            NavigateTo(
+                destination = id,
+                singleInstance = true,
+                clearStackTo = startDestination
+            )
+        )
+    }
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/BackstackHandler.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/BackstackHandler.kt
@@ -1,0 +1,55 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kotlin.reflect.KClass
+
+internal class BackstackHandler {
+
+    internal fun clearBackStack(
+        backStack: NavBackStack<NavKey>,
+        clearStackToInstance: KClass<*>?,
+        clearStackToDestination: NavKey?,
+        clearWithTarget: Boolean
+    ) {
+        if (clearStackToInstance != null) {
+            backStack.clearStackToInstance(clearStackToInstance, clearWithTarget)
+        }
+        if (clearStackToDestination != null) {
+            backStack.clearStackToDestination(clearStackToDestination, clearWithTarget)
+        }
+    }
+
+    private fun NavBackStack<NavKey>.clearStackToInstance(
+        navClass: KClass<*>,
+        clearWithTarget: Boolean
+    ) = clearStackToPredicate(
+        clearWithTarget = clearWithTarget,
+        predicate = { navClass.isInstance(it) }
+    )
+
+    private fun NavBackStack<NavKey>.clearStackToDestination(
+        destination: NavKey,
+        clearWithTarget: Boolean
+    ) = clearStackToPredicate(
+        clearWithTarget = clearWithTarget,
+        predicate = { it == destination }
+    )
+
+    private fun NavBackStack<NavKey>.clearStackToPredicate(
+        clearWithTarget: Boolean,
+        predicate: (NavKey) -> Boolean
+    ) {
+        val index = indexOfLast(predicate)
+
+        if (index >= 0) {
+            val targetIndex = when (clearWithTarget) {
+                true -> index
+                false -> index + 1
+            }
+            repeat(size - targetIndex) {
+                removeAt(size - 1)
+            }
+        }
+    }
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/NavigatorController.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/NavigatorController.kt
@@ -1,0 +1,67 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp.template.navigation.NavigatorEvent.NavigateTo
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+import kmp.template.navigation.NavigatorEvent.ReplaceTo
+import kotlin.reflect.KClass
+
+internal class NavigatorController(
+    override val backStack: NavBackStack<NavKey>,
+    internal val backstackHandler: BackstackHandler = BackstackHandler()
+) : Navigator {
+
+    override fun navigate(effect: NavigatorEvent) {
+        when (effect) {
+            is NavigateTo -> onNavigate(
+                destination = effect.destination,
+                singleInstance = effect.singleInstance,
+                clearStackTo = effect.clearStackTo,
+                clearWithTarget = false
+            )
+            is ReplaceTo -> onNavigate(
+                destination = effect.destination,
+                singleInstance = false,
+                clearStackTo = backStack.last()::class,
+                clearWithTarget = true
+            )
+            is NavigateUp -> onNavigateBack(
+                clearStackTo = effect.clearStackTo
+            )
+        }
+    }
+
+    private fun onNavigate(
+        destination: NavKey,
+        singleInstance: Boolean,
+        clearStackTo: KClass<*>?,
+        clearWithTarget: Boolean
+    ) {
+        backstackHandler.clearBackStack(
+            backStack = backStack,
+            clearStackToInstance = clearStackTo,
+            clearStackToDestination = destination.takeIf { singleInstance },
+            clearWithTarget = clearWithTarget
+        )
+
+        if (backStack.lastOrNull() != destination || !singleInstance) {
+            backStack.add(destination)
+        }
+    }
+
+    private fun onNavigateBack(
+        clearStackTo: KClass<*>?
+    ) {
+        if (backStack.size > 1) {
+            backstackHandler.clearBackStack(
+                backStack = backStack,
+                clearStackToInstance = clearStackTo,
+                clearStackToDestination = backStack.last().takeIf { clearStackTo == null },
+                clearWithTarget = clearStackTo == null
+            )
+        }
+    }
+}

--- a/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/NavigatorPreview.kt
+++ b/module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/NavigatorPreview.kt
@@ -1,0 +1,15 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+
+internal class NavigatorPreview(initialRoute: NavKey) : Navigator {
+
+    override val backStack: NavBackStack<NavKey> = NavBackStack(initialRoute)
+
+    override fun navigate(effect: NavigatorEvent) {
+        // not implemented for preview
+    }
+}

--- a/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/compose/NavigatorTabControllerTest.kt
+++ b/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/compose/NavigatorTabControllerTest.kt
@@ -1,0 +1,60 @@
+package kmp.template.navigation.compose
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent.NavigateTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NavigatorTabControllerTest {
+
+    private object TabA : NavKey
+    private object TabB : NavKey
+
+    private val navigator = mock<Navigator> {
+        every { backStack } calls { NavBackStack(TabA) }
+        every { navigate(any()) } returns Unit
+    }
+
+    private val tested = NavigatorTabControllerScope(
+        navigator = navigator,
+        startDestination = TabA::class
+    )
+
+    @Test
+    fun `navigates to TabB and clears back stack to start destination when TabB is selected`() {
+        tested.navigateToNavigationBar(id = TabB)
+
+        verify {
+            navigator.navigate(
+                effect = NavigateTo(
+                    destination = TabB,
+                    singleInstance = true,
+                    clearStackTo = TabA::class
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `throws exception when destination id does not inherit from NavKey`() {
+        val invalidKey = "invalidKey"
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            tested.navigateToNavigationBar(id = invalidKey)
+        }
+
+        assertEquals(
+            expected = "Unsupported type: $invalidKey - in Navigation3 destination should inherit from NavKey interface.",
+            actual = error.message
+        )
+    }
+}

--- a/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/BackstackHandlerTest.kt
+++ b/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/BackstackHandlerTest.kt
@@ -1,0 +1,185 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BackstackHandlerTest {
+
+    private val tested = BackstackHandler()
+
+    @Test
+    fun `clears back stack when clear is called on existing instance without target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = B::class,
+            clearStackToDestination = null,
+            clearWithTarget = false
+        )
+
+        assertEquals(listOf(A(1), B), stack.toList())
+    }
+
+    @Test
+    fun `clears back stack when clear is called on existing instance with target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = B::class,
+            clearStackToDestination = null,
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1)), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called on the last instance without target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = A::class,
+            clearStackToDestination = null,
+            clearWithTarget = false
+        )
+
+        assertEquals(listOf(A(1), B, A(2), A(3)), stack.toList())
+    }
+
+    @Test
+    fun `clears back stack when clear is called on existing destination without target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = A(2),
+            clearWithTarget = false
+        )
+
+        assertEquals(listOf(A(1), B, A(2)), stack.toList())
+    }
+
+    @Test
+    fun `clears back stack when clear is called on existing destination with target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = A(2),
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1), B), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called on the last destination without target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = A(3),
+            clearWithTarget = false
+        )
+
+        assertEquals(listOf(A(1), B, A(2), A(3)), stack.toList())
+    }
+
+    @Test
+    fun `clears whole back stack when clear is called on first destination with target`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = A(1),
+            clearWithTarget = true
+        )
+
+        assertEquals(emptyList(), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called on empty back stack`() {
+        val stack = NavBackStack<NavKey>()
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = A::class,
+            clearStackToDestination = null,
+            clearWithTarget = true
+        )
+
+        assertEquals(emptyList(), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called on not existing instances`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = C::class,
+            clearStackToDestination = A(100),
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1), B, A(2), A(3)), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called on not existing destination`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = A(100),
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1), B, A(2), A(3)), stack.toList())
+    }
+
+    @Test
+    fun `clear back stack when clear is called with destination and instances`() {
+        val stack = NavBackStack(A(1), B, A(2), C, B)
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = A::class,
+            clearStackToDestination = B,
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1)), stack.toList())
+    }
+
+    @Test
+    fun `does nothing when clear back stack is called without destination and instances`() {
+        val stack = NavBackStack(A(1), B, A(2), A(3))
+
+        tested.clearBackStack(
+            backStack = stack,
+            clearStackToInstance = null,
+            clearStackToDestination = null,
+            clearWithTarget = true
+        )
+
+        assertEquals(listOf(A(1), B, A(2), A(3)), stack.toList())
+    }
+
+    companion object {
+        private data class A(val id: Int) : NavKey
+        private data object B : NavKey
+        private data object C : NavKey
+    }
+}

--- a/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/NavigatorControllerTest.kt
+++ b/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/NavigatorControllerTest.kt
@@ -1,0 +1,94 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import kmp.template.navigation.NavigatorEvent.NavigateTo
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+import kmp.template.navigation.NavigatorEvent.ReplaceTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NavigatorControllerTest {
+
+    private val tested = NavigatorController(
+        backStack = NavBackStack(AKey)
+    )
+
+    @Test
+    fun `navigates to new destination when navigate is called with new destination`() {
+        tested.navigate(NavigateTo(destination = BKey))
+
+        assertEquals(listOf(AKey, BKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `navigates single time to destination when navigate is called several times and singleInstance is true`() {
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = true))
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = true))
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = true))
+
+        assertEquals(listOf(AKey, BKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `navigates several times to destination when navigate is called several times and singleInstance is false`() {
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = false))
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = false))
+        tested.navigate(NavigateTo(destination = BKey, singleInstance = false))
+
+        assertEquals(listOf(AKey, BKey, BKey, BKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `replaces destination on back stack when navigate is called with ReplaceTo event`() {
+        tested.navigate(ReplaceTo(destination = BKey))
+
+        assertEquals(listOf(BKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `throws exception when navigate is called with ReplaceTo event on empty backstack`() {
+        tested.backStack.clear()
+
+        assertFailsWith<NoSuchElementException> {
+            tested.navigate(ReplaceTo(destination = BKey))
+        }
+    }
+
+    @Test
+    fun `pops destination from back stack when navigate is called with NavigateUp event`() {
+        tested.navigate(NavigateTo(destination = BKey))
+
+        tested.navigate(NavigateUp())
+
+        assertEquals(listOf(AKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `keeps back stack with single destination intact when navigate is called with NavigateUp event`() {
+        tested.navigate(NavigateUp())
+
+        assertEquals(listOf(AKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `keeps back stack with single destination intact when navigate is called with NavigateUp parameter`() {
+        tested.navigate(NavigateUp(clearStackTo = AKey::class))
+
+        assertEquals(listOf(AKey), tested.backStack.toList())
+    }
+
+    @Test
+    fun `keeps back stack intact when navigate is called with NavigateUp with invalid parameter`() {
+        tested.navigate(NavigateUp(clearStackTo = CKey::class))
+
+        assertEquals(listOf(AKey), tested.backStack.toList())
+    }
+
+    companion object {
+        private object AKey : NavKey
+        private object BKey : NavKey
+        private object CKey : NavKey
+    }
+}

--- a/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/NavigatorPreviewTest.kt
+++ b/module/library/navigation/src/commonTest/kotlin/kmp/template/navigation/internal/NavigatorPreviewTest.kt
@@ -1,0 +1,19 @@
+package kmp.template.navigation.internal
+
+import androidx.navigation3.runtime.NavKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NavigatorPreviewTest {
+
+    @Test
+    fun `creates navigator preview which starts with initial route`() {
+        val preview = NavigatorPreview(initialRoute = Start)
+
+        assertEquals(listOf(Start), preview.backStack.toList())
+    }
+
+    companion object {
+        private object Start : NavKey
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,5 +25,6 @@ include(
     ":module:library:design",
     ":module:library:environment",
     ":module:library:foundation",
+    ":module:library:navigation",
     ":module:library:network"
 )


### PR DESCRIPTION
This commit introduces a navigation library based on `androidx.navigation3` and refactors the `sample` feature to adopt a multi-screen architecture.

- **Navigation Library (`:module:library:navigation`):**
    - Created a new library module to abstract `androidx.navigation3`.
    - Implemented a `Navigator` interface and `NavigatorController` for handling navigation events (`NavigateTo`, `ReplaceTo`, `NavigateUp`).
    - Added `rememberNavigator` and `NavigatorDisplay` composables for easy integration.
    - Introduced `NavigatorTabController` to manage bottom navigation bar state and logic.
    - Upgraded `androidx.lifecycle` and added `androidx.navigation3` dependencies.

- **Sample Feature Refactor:**
    - The monolithic `SampleScreen` has been dismantled and replaced by a navigation host.
    - Introduced a `SampleHomeScreen` as the main entry point, featuring buttons to navigate to other screens.
    - Created new screens: `SampleDesignScreen`, `SampleEnvironmentScreen`, and `SampleAboutScreen`, each with its own ViewModel, ViewState, and Intent.
    - Implemented bottom navigation for `Home` and `About` tabs.
    - Defined navigation routes using a sealed interface `SampleRoute`.
    - Updated Koin dependency injection to provide ViewModels for the new screens.

- **Foundation & Design System:**
    - In `SideEffectDispatcher`, switched to `Dispatchers.Main.immediate` for UI side effect handling.
    - Added a `Content` state to `ScreenStateUiModel` to represent a successfully loaded state without a fullscreen overlay.
    - Updated navigation components (`AppNavigationBar`, `AppNavigationDrawer`, etc.) to use `id` instead of `route` for better clarity.