### PR TITLE
ci: introduce check and build GitHub actions workflows

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -1,0 +1,17 @@
+# GitHub common initial configuration
+name: "Init Environment"
+description: "Initialize environment for CI/CD workflows"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup Java JDK"
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: "Setup Gradle Cache"
+      uses: gradle/actions/setup-gradle@v5
+      with:
+        validate-wrappers: true

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -1,0 +1,18 @@
+# GitHub common report configuration
+name: "Results Report"
+description: "Upload Gradle reports from all modules"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Upload Gradle Reports"
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ github.job }}-report
+        path: |
+          app/build/reports/**
+          module/feature/*/build/reports/**
+          module/library/*/build/reports/**
+          module/service/*/build/reports/**
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -1,0 +1,75 @@
+# GitHub Actions project compilation workflow
+name: "Project Build"
+on:
+  push:
+    branches:
+      - main
+      - release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-target:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Setup Environment"
+        uses: ./.github/actions/init
+
+      - name: "Compile Android Target"
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: "Test Android Target"
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: "Upload Android Report"
+        if: always()
+        uses: ./.github/actions/report
+
+  ios-target:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Setup Environment"
+        uses: ./.github/actions/init
+
+      - name: "Select Xcode"
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: "Compile iOS Target"
+        run: cd iosApp && xcodebuild -target "iosApp" -configuration Debug -scheme "iosApp" -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16' CODE_SIGNING_ALLOWED='NO'
+
+      - name: "Test iOS Target"
+        run: ./gradlew iosSimulatorArm64Test --stacktrace
+
+      - name: "Upload iOS Report"
+        if: always()
+        uses: ./.github/actions/report
+
+  jvm-target:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Setup Environment"
+        uses: ./.github/actions/init
+
+      - name: "Compile JVM Target"
+        run: ./gradlew compileKotlinJvm --stacktrace
+
+      - name: "Test JVM Target"
+        run: ./gradlew jvmTest --stacktrace
+
+      - name: "Upload JVM Report"
+        if: always()
+        uses: ./.github/actions/report

--- a/.github/workflows/project-check.yml
+++ b/.github/workflows/project-check.yml
@@ -1,0 +1,33 @@
+# GitHub Actions project verification workflow
+name: "Project Check"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Setup Environment"
+        uses: ./.github/actions/init
+
+      - name: "Detekt Check"
+        run: ./gradlew detekt --stacktrace
+
+      - name: "Lint Check"
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: "Test Check"
+        run: ./gradlew test --stacktrace
+
+      - name: "Upload Report"
+        if: always()
+        uses: ./.github/actions/report

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ kotlin.daemon.jvmargs=-Xmx4096M
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 org.gradle.caching=true
+org.gradle.parallel=true
 
 #Android
 android.nonTransitiveRClass=true

--- a/gradle/build-logic/src/main/kotlin/plugin/configuration/DetektPluginConfiguration.kt
+++ b/gradle/build-logic/src/main/kotlin/plugin/configuration/DetektPluginConfiguration.kt
@@ -38,7 +38,7 @@ internal class DetektPluginConfiguration : BuildLogicConfiguration {
 
             reports {
                 checkstyle.required.set(true)
-                html.required.set(false)
+                html.required.set(true)
                 markdown.required.set(false)
                 sarif.required.set(false)
             }


### PR DESCRIPTION
This commit adds GitHub Actions workflows to automate building, testing, and code checking for the project. It also introduces common actions for environment setup and report uploading, and enables parallel execution in Gradle.

- **Workflows:**
    - `project-build.yml`: Compiles and runs unit tests for Android, iOS, and JVM targets on `push` events to `main` and `release` branches.
    - `project-check.yml`: Runs Detekt, Lint, and all tests on every `pull_request`.
- **Actions:**
    - `init`: A composite action to set up the Java 17 JDK and configure the Gradle cache.
    - `report`: A composite action to upload Gradle reports as build artifacts for all modules.
- **Gradle:**
    - Enabled parallel project execution via `org.gradle.parallel=true`.
    - Enabled HTML reports for Detekt to improve readability.
    - Adjusted Android Lint configuration to stop checking dependencies and to include test sources.