### PR TITLE
feat: add preferences library module for data persistence

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,153 @@
+# Project Guidelines — KMP Template
+
+This document summarizes the conventions, architecture, organization, and testing practices used across the codebase. It is derived from the current source (examples referenced inline).
+
+## 1) Coding conventions
+
+- Language and targets
+  - Kotlin Multiplatform with common, Android, iOS, JVM and Wasm targets (see root `build.gradle.kts` with Compose Multiplatform, SQLDelight, Koin, and related plugins).
+  - Prefer `expect/actual` for platform integration boundaries; keep common logic in `commonMain`. Example: `preferencesPlatformModule` is `expect` in common and `actual` in `androidMain` providing the SQLDelight driver factory (`module/library/preferences/src/androidMain/.../PreferencesModule.android.kt`).
+
+- Visibility and API surface
+  - Default to `internal` for implementation details within a module. Public API surfaces are intentionally small (e.g., `kmp.template.preferences.Preferences` is public, while `DbPreferences` and DAO types live under `.internal`).
+  - Keep package visibility coherent with module boundaries, e.g., `kmp.template.preferences.internal.*` for non-API implementation.
+
+- Naming
+  - Classes and interfaces: PascalCase.
+  - Functions and properties: camelCase.
+  - Test classes: `<TypeUnderTest>Test` (see multiple tests in `module/library/preferences/src/commonTest/...`). Behavior-style function names are allowed with backticks.
+  - Use meaningful domain terms for navigation keys and events (`NavigatorEvent.NavigateTo`, `ReplaceTo`, `NavigateUp`).
+
+- Coroutines
+  - Use structured concurrency via scopes provided by framework types. For ViewModels, use `viewModelScope` (see `MviViewModel`).
+  - Offload IO/CPU work via explicit dispatchers and `withContext` (see `DbPreferences` using `Dispatchers.Default` for DAO access).
+  - Configuration for coroutine context is injected/configurable for MVI (`MviConfig`/`MviDefaultConfig`).
+
+- Error handling
+  - Prefer typed exceptions for domain-specific errors (e.g., `PreferencesKeyNotFound`).
+  - Let type mismatches surface at call site when appropriate (serializer decode generics intentionally allow `ClassCastException` if misused — covered by tests).
+
+- Immutability and state
+  - UI state managed via `StateFlow` and updated with `.update { }`. One-off effects via `Channel` exposed as `Flow` (see `MviViewModel`).
+  - Use data classes and sealed interfaces for events/commands (`NavigatorEvent`).
+
+- Serialization and type safety
+  - Minimal, explicit serializers for primitives (`PrimitivesSerializer`) with strict parsing (e.g., booleans via `toBooleanStrict`).
+
+- Compose and Stability
+  - Use Compose Multiplatform. Keep navigation facade `@Stable` where it’s observed by UI (`Navigator`).
+
+- Static analysis and style
+  - Detekt codestyle plugin is applied at the root. Follow its enforced style guidelines (imports order, naming, formatting). Keep code idiomatic and consistent with the existing style.
+
+## 2) Architecture patterns and best practices
+
+- Layering and modules
+  - Clear separation between app, features, and libraries:
+    - Libraries: reusable building blocks (e.g., `foundation` for MVI, `navigation` for navigation facade, `preferences` for storage).
+    - Feature modules: UI + ViewModels built on top of library layers (e.g., `module/feature/sample`).
+    - App modules (Android/iOS) assemble and wire dependencies.
+
+- Dependency Injection
+  - Koin is used for DI with module-per-area organization. Example: `preferencesModule` includes platform bindings and provides DAO/Serializer, and exposes `Preferences` implementation (`DbPreferences`). ViewModels are registered via `viewModelOf` in feature modules (see `SampleModule`).
+  - Platform-specific services are bound via `expect/actual` Koin modules for each target.
+
+- MVI (Model–View–Intent)
+  - Base class `MviViewModel<ViewState>` provides:
+    - `StateFlow<ViewState>` for state.
+    - `Flow<Any>` for side effects via a `Channel`.
+    - `launch {}` helper that uses configured dispatcher and exception handler (`MviConfig`).
+    - `transform {}` to apply pure state reducers.
+  - Best practices:
+    - Keep intents small and deterministic; run business logic inside `launch`.
+    - Emit side effects for one-off events; keep state serializable/plain.
+
+- Navigation
+  - Cross-platform navigation facade around `androidx.navigation3.runtime` types.
+  - `Navigator` exposes a `NavBackStack<NavKey>` and a single entry point `navigate(event: NavigatorEvent)`.
+  - `NavigatorController` centralizes back-stack manipulations, including single-instance routing and back-stack clearing policies.
+  - Prefer sealed `NavigatorEvent` commands over ad-hoc navigation calls, enabling testability (`NavigatorControllerTest`, `NavigatorTabControllerTest`).
+
+- Data and storage
+  - SQLDelight-backed persistence hidden behind simple interfaces/DAO. `DbPreferences` depends on a `PreferencesDao` and a serializer, and runs work on a background dispatcher with `withContext`.
+  - Use small, focused models for serialization (`SerializedModel`, `SerializedType`).
+
+- Cross-platform boundaries
+  - Use `expect/actual` for drivers and platform services. Keep interfaces in common, implementations per target (e.g., Android provides `AndroidDatabaseDriverFactory`).
+
+## 3) Code organization and package structure
+
+- Source sets per module
+  - `src/commonMain/kotlin` for shared code; `src/androidMain`, `src/iosMain`, `src/wasmJsMain` for platform specifics.
+  - `src/commonTest/kotlin` for shared tests that do not require platform drivers.
+
+- Packages
+  - Root package: `kmp.template.*`.
+  - Library modules
+    - Foundation: `kmp.template.foundation.*` (e.g., `mvi`, `config`).
+    - Navigation: `kmp.template.navigation.*` (`Navigator`, `NavigatorEvent`, internal controller and compose helpers).
+    - Preferences: `kmp.template.preferences.*` with `internal` subpackages: `db`, `serializer`, `di`.
+  - Feature modules
+    - Example feature: `kmp.template.feature.sample.*` organized by presentation (ViewModels) and DI (`SampleModule`).
+
+- Internal vs public
+  - Public APIs live at the module root (e.g., `Preferences` interface). Implementation details live under `.internal` and are not exported.
+
+- Build and plugins
+  - Root `build.gradle.kts` declares plugin aliases: Android, KMP, Compose Multiplatform, SQLDelight, Koin, Detekt, AtomicFu, Serialization, and Mokkery. Concrete configurations are per-module.
+
+## 4) Unit and integration testing approaches
+
+- Frameworks and assertions
+  - Use `kotlin.test` assertions (`assertEquals`, `assertTrue`, `assertFailsWith`, etc.).
+  - Use `kotlinx.coroutines.test.runTest {}` for coroutine tests. Do not mark test functions as `suspend`.
+
+- Structure and naming
+  - Test class names mirror the type under test with `Test` suffix.
+  - Arrange/Act/Assert (AAA) layout; keep tests single-purpose and deterministic.
+
+- Test doubles and DI
+  - Prefer simple in-memory fakes in `commonTest` to avoid platform drivers (e.g., fake `PreferencesDataSource`/DAO for `DbPreferences`).
+  - Construct SUTs directly in tests. Only wire DI when the test targets DI.
+
+- Concurrency and dispatchers
+  - Use test dispatchers (`StandardTestDispatcher`) when verifying ordering/scheduling.
+  - For simple cases, `Dispatchers.Unconfined` may be used within tests per guidelines.
+
+- Storage and serialization tests
+  - Cover round-trips for all supported primitives in `PrimitivesSerializer`.
+  - Validate strict boolean parsing (`toBooleanStrict`) raising `IllegalArgumentException` for invalid inputs.
+  - Validate preferences behaviors: `getOrThrow`, `getOrDefault`, `hasKey`, `remove`, `clear`, overwrite semantics, and type safety expectations.
+
+- Navigation tests
+  - Verify back-stack behavior using `NavigatorControllerTest` and tab controller tests under `module/library/navigation/src/commonTest`.
+
+- Platform scope
+  - Keep tests in `commonTest` free of platform driver dependencies to run on all targets (including Wasm). Avoid direct SQL/web drivers in unit tests.
+
+- Tools
+  - Mokkery plugin is available if mocking is needed; prefer fakes where simpler and clearer.
+
+## References (non-exhaustive)
+
+- Foundation MVI
+  - `module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/MviViewModel.kt`
+  - `module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/mvi/config/MviConfig.kt`
+
+- Navigation
+  - `module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/Navigator.kt`
+  - `module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/NavigatorEvent.kt`
+  - `module/library/navigation/src/commonMain/kotlin/kmp/template/navigation/internal/NavigatorController.kt`
+  - Tests under `module/library/navigation/src/commonTest/...`
+
+- Preferences
+  - `module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/DbPreferences.kt`
+  - `module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/di/PreferencesModule.kt`
+  - `module/library/preferences/src/androidMain/kotlin/kmp/template/preferences/di/PreferencesModule.android.kt`
+  - Tests under `module/library/preferences/src/commonTest/...`
+
+- Sample feature
+  - `module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt`
+
+- Build
+  - Root `build.gradle.kts` for plugin landscape

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
             implementation(projects.module.library.network)
+            implementation(projects.module.library.preferences)
 
             implementation(libs.bundles.compose)
             implementation(libs.koin.compose)

--- a/app/src/commonMain/kotlin/kmp/template/app/di/DiModules.kt
+++ b/app/src/commonMain/kotlin/kmp/template/app/di/DiModules.kt
@@ -2,6 +2,7 @@ package kmp.template.app.di
 
 import kmp.template.feature.sample.di.sampleModule
 import kmp.template.network.di.networkModule
+import kmp.template.preferences.di.preferencesModule
 import org.koin.core.module.Module
 
 internal expect val appModule: Module
@@ -11,7 +12,8 @@ internal val featureModules: List<Module> = listOf(
 )
 
 internal val libraryModules: List<Module> = listOf(
-    networkModule
+    networkModule,
+    preferencesModule
 )
 
 internal val serviceModules: List<Module> = listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,4 +9,5 @@ plugins {
     alias(libs.plugins.kotlinSerialization) apply false
     alias(libs.plugins.kotlinxAtomicFu) apply false
     alias(libs.plugins.mokkery) apply false
+    alias(libs.plugins.sqldelight) apply false
 }

--- a/gradle/build-logic/src/main/kotlin/plugin/configuration/KmpTargetsConfiguration.kt
+++ b/gradle/build-logic/src/main/kotlin/plugin/configuration/KmpTargetsConfiguration.kt
@@ -31,7 +31,8 @@ internal class KmpTargetsConfiguration : BuildLogicConfiguration {
                 if (isApplicationModule) {
                     binaries.framework {
                         baseName = "App"
-                        isStatic = true
+                        isStatic = false
+                        linkerOpts.add("-lsqlite3")
                     }
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,10 +14,13 @@ kermit = "2.0.8"
 koin = "4.1.1"
 kotlin = "2.2.21"
 kotlinx-atomic = "0.29.0"
+kotlinx-browser = "0.5.0"
 kotlinx-coroutines = "1.10.2"
+kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.9.0"
 ktor = "3.3.3"
 mokkery = "3.0.0"
+sqldelight = "2.2.1"
 
 [libraries]
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
@@ -47,9 +50,11 @@ koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 
 # Kotlin
+kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Ktor
@@ -61,6 +66,13 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-wasm = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+# SQLDelight
+sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
+sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
+sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+sqldelight-web-driver = { module = "app.cash.sqldelight:web-worker-driver", version.ref = "sqldelight" }
 
 # Gradle-config
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
@@ -102,3 +114,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinxAtomicFu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomic" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
+sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }

--- a/module/feature/sample/build.gradle.kts
+++ b/module/feature/sample/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
             implementation(projects.module.library.navigation)
+            implementation(projects.module.library.preferences)
 
             implementation(libs.bundles.compose)
             implementation(libs.bundles.lifecycle)

--- a/module/feature/sample/src/commonMain/composeResources/values/strings.xml
+++ b/module/feature/sample/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="sample_home_card_header">Features</string>
     <string name="sample_home_card_design_label">Design System</string>
     <string name="sample_home_card_environment_label">Environment</string>
+    <string name="sample_home_card_storage_label">Storage Demo</string>
 
     <string name="sample_design_screen_header">Sample Design System</string>
     <string name="sample_design_fonts_card_header">Fonts</string>
@@ -21,6 +22,18 @@
     <string name="sample_environment_app_id_label">Application id: %1$s</string>
     <string name="sample_environment_version_label">Version name: %1$s</string>
     <string name="sample_environment_debug_label">Debug build: %1$s</string>
+
+    <string name="storage_demo_screen_header">Storage Demo</string>
+    <string name="storage_demo_counter_card_header">Screen statistics</string>
+    <string name="storage_demo_counter_card_viewmodel_label">ViewModel init counter: %1$d</string>
+    <string name="storage_demo_counter_card_screen_label">Compose init counter: %1$d</string>
+    <string name="storage_demo_interactive_header">Storage Controller</string>
+    <string name="storage_demo_interactive_value_label">Interactive value: %1$d</string>
+    <string name="storage_demo_interactive_key_label">Interactive value exists: %1$s</string>
+    <string name="storage_demo_interactive_increment_button">Increment</string>
+    <string name="storage_demo_interactive_decrement_button">Decrement</string>
+    <string name="storage_demo_interactive_remove_button">Remove key</string>
+    <string name="storage_demo_interactive_clear_button">Clear full storage</string>
 
     <string name="sample_about_screen_header">About Template</string>
     <string name="sample_about_card_header">KMP Project</string>

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
@@ -5,6 +5,7 @@ import kmp.template.feature.sample.presentation.about.SampleAboutViewModel
 import kmp.template.feature.sample.presentation.design.SampleDesignViewModel
 import kmp.template.feature.sample.presentation.environment.SampleEnvironmentViewModel
 import kmp.template.feature.sample.presentation.home.SampleHomeViewModel
+import kmp.template.feature.sample.presentation.storage.StorageDemoViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -17,4 +18,5 @@ val sampleModule: Module = module {
     viewModelOf(::SampleEnvironmentViewModel)
     viewModelOf(::SampleHomeViewModel)
     viewModelOf(::SampleViewModel)
+    viewModelOf(::StorageDemoViewModel)
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
@@ -16,5 +16,8 @@ internal sealed interface SampleRoute : NavKey {
     data object SampleEnvironmentDestination : SampleRoute
 
     @Serializable
+    data object StorageDemoDestination : SampleRoute
+
+    @Serializable
     data object AboutDestination : SampleRoute
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
@@ -19,10 +19,12 @@ import kmp.template.feature.sample.navigation.SampleRoute.AboutDestination
 import kmp.template.feature.sample.navigation.SampleRoute.HomeDestination
 import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
 import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.navigation.SampleRoute.StorageDemoDestination
 import kmp.template.feature.sample.presentation.about.SampleAboutScreen
 import kmp.template.feature.sample.presentation.design.SampleDesignScreen
 import kmp.template.feature.sample.presentation.environment.SampleEnvironmentScreen
 import kmp.template.feature.sample.presentation.home.SampleHomeScreen
+import kmp.template.feature.sample.presentation.storage.StorageDemoScreen
 import kmp.template.navigation.Navigator
 import kmp.template.navigation.compose.NavigatorDisplay
 import kmp.template.navigation.compose.NavigatorTabController
@@ -36,6 +38,7 @@ import kotlinx.serialization.modules.polymorphic
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
+@Suppress("LongMethod")
 @Composable
 fun SampleScreen() {
 
@@ -50,6 +53,7 @@ fun SampleScreen() {
                 subclass(subclass = SampleEnvironmentDestination::class, serializer = SampleEnvironmentDestination.serializer())
                 subclass(subclass = HomeDestination::class, serializer = HomeDestination.serializer())
                 subclass(subclass = AboutDestination::class, serializer = AboutDestination.serializer())
+                subclass(subclass = StorageDemoDestination::class, serializer = StorageDemoDestination.serializer())
             }
         }
     )
@@ -70,6 +74,12 @@ fun SampleScreen() {
             }
             entry<SampleEnvironmentDestination> {
                 SampleEnvironmentScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+            entry<StorageDemoDestination> {
+                StorageDemoScreen(
                     viewModel = koinViewModel(),
                     navigator = navigator
                 )

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
@@ -4,4 +4,5 @@ internal sealed interface SampleHomeIntent {
 
     data object DesignSystemPressed : SampleHomeIntent
     data object EnvironmentPressed : SampleHomeIntent
+    data object StorageDemoPressed : SampleHomeIntent
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
@@ -25,6 +25,7 @@ import kmp.template.design.component.screenstate.ScreenStateUiModel
 import kmp.template.design.theme.AppTheme
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.StorageDemoPressed
 import kmp.template.foundation.lifecycle.SideEffectDispatcher
 import kmp.template.navigation.Navigator
 import kmp.template.navigation.NavigatorEvent
@@ -32,6 +33,7 @@ import kmp_template.module.feature.sample.generated.resources.Res
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_design_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_environment_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_home_card_storage_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_screen_header
 import org.jetbrains.compose.resources.stringResource
 
@@ -119,6 +121,10 @@ private fun SampleHomeCard(
     AppFilledButton(
         label = stringResource(Res.string.sample_home_card_environment_label),
         onClick = { intent(EnvironmentPressed) }
+    )
+    AppFilledButton(
+        label = stringResource(Res.string.sample_home_card_storage_label),
+        onClick = { intent(StorageDemoPressed) }
     )
 }
 

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
@@ -3,8 +3,10 @@ package kmp.template.feature.sample.presentation.home
 import kmp.template.design.component.screenstate.ScreenStateUiModel
 import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
 import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.navigation.SampleRoute.StorageDemoDestination
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.StorageDemoPressed
 import kmp.template.foundation.mvi.MviViewModel
 import kmp.template.navigation.NavigatorEvent.NavigateTo
 
@@ -22,6 +24,7 @@ internal class SampleHomeViewModel : MviViewModel<SampleHomeViewState>(SampleHom
         when (intent) {
             is DesignSystemPressed -> onDesignSystemPressed()
             is EnvironmentPressed -> onEnvironmentPressed()
+            is StorageDemoPressed -> onStorageDemoPressed()
         }
     }
 
@@ -31,5 +34,9 @@ internal class SampleHomeViewModel : MviViewModel<SampleHomeViewState>(SampleHom
 
     private fun onEnvironmentPressed() {
         emitSideEffect(NavigateTo(SampleEnvironmentDestination))
+    }
+
+    private fun onStorageDemoPressed() {
+        emitSideEffect(NavigateTo(StorageDemoDestination))
     }
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoIntent.kt
@@ -1,0 +1,11 @@
+package kmp.template.feature.sample.presentation.storage
+
+internal sealed interface StorageDemoIntent {
+
+    data object ComposeScreenLaunched : StorageDemoIntent
+    data object IncrementValuePressed : StorageDemoIntent
+    data object DecrementValuePressed : StorageDemoIntent
+    data object RemoveKeyPressed : StorageDemoIntent
+    data object ClearStoragePressed : StorageDemoIntent
+    data object NavigateBackPressed : StorageDemoIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoScreen.kt
@@ -1,0 +1,219 @@
+package kmp.template.feature.sample.presentation.storage
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppBodyMediumTextStyle
+import kmp.template.design.component.base.AppButtonRow
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppComponentSpacer
+import kmp.template.design.component.base.AppFilledButton
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppOutlinedButton
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.base.AppTitleTextStyle
+import kmp.template.design.component.screenstate.ScreenStateContent
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.topbar.AppTopCenterBar
+import kmp.template.design.theme.AppTheme
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.ClearStoragePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.ComposeScreenLaunched
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.DecrementValuePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.IncrementValuePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.RemoveKeyPressed
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.storage_demo_counter_card_header
+import kmp_template.module.feature.sample.generated.resources.storage_demo_counter_card_screen_label
+import kmp_template.module.feature.sample.generated.resources.storage_demo_counter_card_viewmodel_label
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_clear_button
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_decrement_button
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_header
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_increment_button
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_key_label
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_remove_button
+import kmp_template.module.feature.sample.generated.resources.storage_demo_interactive_value_label
+import kmp_template.module.feature.sample.generated.resources.storage_demo_screen_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun StorageDemoScreen(
+    viewModel: StorageDemoViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.onIntent(ComposeScreenLaunched)
+    }
+
+    StorageDemoScreen(
+        viewState = viewState,
+        intent = viewModel::onIntent
+    )
+}
+
+@Composable
+private fun StorageDemoScreen(
+    viewState: StorageDemoViewState,
+    intent: (StorageDemoIntent) -> Unit
+) = AppScaffold(
+    topBar = {
+        StorageDemoTopBar(
+            intent = intent
+        )
+    },
+    content = { contentPadding ->
+        StorageDemoContent(
+            viewState = viewState,
+            intent = intent,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(contentPadding)
+        )
+        ScreenStateContent(
+            screenState = viewState.screenState,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StorageDemoTopBar(
+    intent: (StorageDemoIntent) -> Unit
+) = AppTopCenterBar(
+    title = {
+        AppText(text = stringResource(Res.string.storage_demo_screen_header))
+    },
+    navigationIcon = {
+        IconButton(onClick = { intent(NavigateBackPressed) }) {
+            AppIcon(icon = AppTheme.icons.arrowBack)
+        }
+    }
+)
+
+@Composable
+private fun StorageDemoContent(
+    viewState: StorageDemoViewState,
+    intent: (StorageDemoIntent) -> Unit,
+    modifier: Modifier
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(
+        space = AppTheme.dimensions.spaceSm
+    ),
+    contentPadding = PaddingValues(
+        horizontal = AppTheme.dimensions.spaceMd,
+        vertical = AppTheme.dimensions.spaceSm
+    )
+) {
+    item {
+        StorageDemoCounterCard(
+            viewState = viewState,
+            intent = intent,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+    item {
+        StorageDemoInteractiveCard(
+            viewState = viewState,
+            intent = intent,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun StorageDemoCounterCard(
+    viewState: StorageDemoViewState,
+    intent: (StorageDemoIntent) -> Unit,
+    modifier: Modifier
+) = AppCard(
+    modifier = modifier
+) {
+    AppTitleTextStyle {
+        AppText(stringResource(Res.string.storage_demo_counter_card_header))
+    }
+    AppComponentSpacer()
+    AppBodyMediumTextStyle {
+        AppText(stringResource(Res.string.storage_demo_counter_card_viewmodel_label, viewState.viewModelInitCounter))
+        AppText(stringResource(Res.string.storage_demo_counter_card_screen_label, viewState.composeLaunchCounter))
+    }
+    AppComponentSpacer()
+    AppButtonRow {
+        AppOutlinedButton(
+            label = stringResource(Res.string.storage_demo_interactive_clear_button),
+            onClick = { intent(ClearStoragePressed) }
+        )
+    }
+}
+
+@Composable
+private fun StorageDemoInteractiveCard(
+    viewState: StorageDemoViewState,
+    intent: (StorageDemoIntent) -> Unit,
+    modifier: Modifier
+) = AppCard(
+    modifier = modifier
+) {
+    AppTitleTextStyle {
+        AppText(stringResource(Res.string.storage_demo_interactive_header))
+    }
+    AppComponentSpacer()
+    AppBodyMediumTextStyle {
+        AppText(stringResource(Res.string.storage_demo_interactive_value_label, viewState.userInteractValue))
+        AppText(stringResource(Res.string.storage_demo_interactive_key_label, viewState.userInteractKeyExist))
+    }
+    AppComponentSpacer()
+    AppButtonRow(
+        horizontalAlignment = Alignment.Start,
+        horizontalItemLimit = 1
+    ) {
+        AppFilledButton(
+            label = stringResource(Res.string.storage_demo_interactive_increment_button),
+            onClick = { intent(IncrementValuePressed) }
+        )
+        AppFilledButton(
+            label = stringResource(Res.string.storage_demo_interactive_decrement_button),
+            onClick = { intent(DecrementValuePressed) }
+        )
+        AppFilledButton(
+            label = stringResource(Res.string.storage_demo_interactive_remove_button),
+            onClick = { intent(RemoveKeyPressed) }
+        )
+    }
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    StorageDemoScreen(
+        viewState = StorageDemoViewState(
+            screenState = ScreenStateUiModel.Content
+        ),
+        intent = {}
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoViewModel.kt
@@ -1,0 +1,110 @@
+package kmp.template.feature.sample.presentation.storage
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.ClearStoragePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.ComposeScreenLaunched
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.DecrementValuePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.IncrementValuePressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.storage.StorageDemoIntent.RemoveKeyPressed
+import kmp.template.foundation.mvi.MviViewModel
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+import kmp.template.preferences.Preferences
+
+internal class StorageDemoViewModel(
+    private val preferences: Preferences
+) : MviViewModel<StorageDemoViewState>(StorageDemoViewState()) {
+
+    init {
+        initViewState()
+    }
+
+    private fun initViewState() = launch {
+        val viewModelInitCounter = preferences.getOrDefault(SCREEN_INIT_COUNTER_KEY, COUNTER_DEFAULT_VALUE)
+            .also { preferences.set(SCREEN_INIT_COUNTER_KEY, it + 1) }
+
+        val userInteractValue = preferences.getOrDefault(USER_INTERACT_VALUE_KEY, INTERACTOR_DEFAULT_VALUE)
+        val hasUserInteractKey = preferences.hasKey(USER_INTERACT_VALUE_KEY)
+
+        transform {
+            copy(
+                screenState = ScreenStateUiModel.Content,
+                viewModelInitCounter = viewModelInitCounter,
+                userInteractValue = userInteractValue,
+                userInteractKeyExist = hasUserInteractKey
+            )
+        }
+    }
+
+    fun onIntent(intent: StorageDemoIntent) {
+        when (intent) {
+            is ComposeScreenLaunched -> onComposeScreenLaunched()
+            is IncrementValuePressed -> onIncrementValuePressed()
+            is DecrementValuePressed -> onDecrementValuePressed()
+            is RemoveKeyPressed -> onRemoveKeyPressed()
+            is ClearStoragePressed -> onClearStoragePressed()
+            is NavigateBackPressed -> onNavigateBackPressed()
+        }
+    }
+
+    private fun onComposeScreenLaunched() = launch {
+        val composeLaunchCounter = preferences.getOrDefault(COMPOSE_LAUNCH_COUNTER_KEY, COUNTER_DEFAULT_VALUE)
+            .also { preferences.set(COMPOSE_LAUNCH_COUNTER_KEY, it + 1) }
+
+        transform { copy(composeLaunchCounter = composeLaunchCounter) }
+    }
+
+    private fun onIncrementValuePressed() = launch {
+        updateInteractiveValue { it + 1 }
+    }
+
+    private fun onDecrementValuePressed() = launch {
+        updateInteractiveValue { it - 1 }
+    }
+
+    private suspend fun updateInteractiveValue(predicate: (Long) -> Long) {
+        val newValue = predicate(viewState.value.userInteractValue)
+        preferences.set(USER_INTERACT_VALUE_KEY, newValue)
+
+        transform {
+            copy(
+                userInteractValue = newValue,
+                userInteractKeyExist = true
+            )
+        }
+    }
+
+    private fun onRemoveKeyPressed() = launch {
+        preferences.remove(USER_INTERACT_VALUE_KEY)
+        transform {
+            copy(
+                userInteractValue = INTERACTOR_DEFAULT_VALUE,
+                userInteractKeyExist = false
+            )
+        }
+    }
+
+    private fun onClearStoragePressed() = launch {
+        preferences.clear()
+        transform {
+            copy(
+                viewModelInitCounter = 0,
+                composeLaunchCounter = 0,
+                userInteractValue = INTERACTOR_DEFAULT_VALUE,
+                userInteractKeyExist = false
+            )
+        }
+    }
+
+    private fun onNavigateBackPressed() {
+        emitSideEffect(NavigateUp())
+    }
+
+    private companion object {
+        const val SCREEN_INIT_COUNTER_KEY = "screenInitCounter"
+        const val COMPOSE_LAUNCH_COUNTER_KEY = "composeLaunchCounter"
+        const val USER_INTERACT_VALUE_KEY = "userInteractValue"
+        const val COUNTER_DEFAULT_VALUE = 1
+        const val INTERACTOR_DEFAULT_VALUE = 0L
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/storage/StorageDemoViewState.kt
@@ -1,0 +1,12 @@
+package kmp.template.feature.sample.presentation.storage
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+
+internal data class StorageDemoViewState(
+    val screenState: ScreenStateUiModel = Loading(),
+    val viewModelInitCounter: Int = 0,
+    val composeLaunchCounter: Int = 0,
+    val userInteractValue: Long = 0L,
+    val userInteractKeyExist: Boolean = false
+)

--- a/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppButton.kt
+++ b/module/library/design/src/commonMain/kotlin/kmp/template/design/component/base/AppButton.kt
@@ -160,6 +160,7 @@ fun AppButtonRow(
     itemPadding: Dp = AppTheme.dimensions.spaceSm,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    horizontalItemLimit: Int = Int.MAX_VALUE,
     content: @Composable FlowRowScope.() -> Unit
 ) = FlowRow(
     verticalArrangement = Arrangement.spacedBy(
@@ -170,6 +171,7 @@ fun AppButtonRow(
         alignment = horizontalAlignment,
         space = itemPadding
     ),
+    maxItemsInEachRow = horizontalItemLimit,
     modifier = modifier,
     content = content
 )

--- a/module/library/foundation/build.gradle.kts
+++ b/module/library/foundation/build.gradle.kts
@@ -9,8 +9,7 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.androidx.lifecycle.runtime)
-            implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(libs.bundles.lifecycle)
             implementation(libs.kermit)
             implementation(libs.kotlinx.coroutines.core)
         }

--- a/module/library/preferences/build.gradle.kts
+++ b/module/library/preferences/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.gradleBuildLogic)
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.sqldelight)
+    alias(libs.plugins.mokkery)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.kermit)
+            implementation(libs.koin.core)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.datetime)
+            implementation(libs.sqldelight.runtime)
+        }
+        commonTest.dependencies {
+            implementation(libs.bundles.unitTest)
+        }
+        androidMain.dependencies {
+            implementation(libs.sqldelight.android.driver)
+        }
+        iosMain.dependencies {
+            implementation(libs.sqldelight.native.driver)
+        }
+        jvmMain.dependencies {
+            implementation(libs.sqldelight.sqlite.driver)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.kotlinx.browser)
+            implementation(libs.sqldelight.web.driver)
+        }
+    }
+}
+
+android {
+    namespace = "kmp.template.preferences"
+}
+
+sqldelight {
+    databases {
+        create("PreferencesDb") {
+            packageName.set("kmp.template.preferences.db")
+            generateAsync.set(true)
+        }
+    }
+}

--- a/module/library/preferences/src/androidMain/kotlin/kmp/template/preferences/di/PreferencesModule.android.kt
+++ b/module/library/preferences/src/androidMain/kotlin/kmp/template/preferences/di/PreferencesModule.android.kt
@@ -1,0 +1,13 @@
+package kmp.template.preferences.di
+
+import kmp.template.preferences.internal.db.AndroidDatabaseDriverFactory
+import kmp.template.preferences.internal.db.DatabaseDriverFactory
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val preferencesPlatformModule: Module = module {
+
+    singleOf(::AndroidDatabaseDriverFactory) bind DatabaseDriverFactory::class
+}

--- a/module/library/preferences/src/androidMain/kotlin/kmp/template/preferences/internal/db/AndroidDatabaseDriverFactory.kt
+++ b/module/library/preferences/src/androidMain/kotlin/kmp/template/preferences/internal/db/AndroidDatabaseDriverFactory.kt
@@ -1,0 +1,19 @@
+package kmp.template.preferences.internal.db
+
+import android.content.Context
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import kmp.template.preferences.db.PreferencesDb
+
+internal class AndroidDatabaseDriverFactory(
+    private val context: Context
+) : DatabaseDriverFactory {
+
+    override fun createDriver(): SqlDriver =
+        AndroidSqliteDriver(
+            schema = PreferencesDb.Schema.synchronous(),
+            context = context,
+            name = DatabaseConstants.DB_NAME
+        )
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/Preferences.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/Preferences.kt
@@ -1,0 +1,16 @@
+package kmp.template.preferences
+
+interface Preferences {
+
+    suspend fun <T : Any> getOrThrow(key: String): T
+
+    suspend fun <T : Any> getOrDefault(key: String, default: T): T
+
+    suspend fun <T : Any> set(key: String, value: T)
+
+    suspend fun hasKey(key: String): Boolean
+
+    suspend fun remove(key: String)
+
+    suspend fun clear()
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/di/PreferencesModule.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/di/PreferencesModule.kt
@@ -1,0 +1,33 @@
+package kmp.template.preferences.di
+
+import kmp.template.preferences.Preferences
+import kmp.template.preferences.internal.DbPreferences
+import kmp.template.preferences.internal.db.DatabaseQueryProvider
+import kmp.template.preferences.internal.db.dao.PreferencesDao
+import kmp.template.preferences.internal.db.dao.PreferencesDbDao
+import kmp.template.preferences.internal.serializer.PrimitivesSerializer
+import kotlinx.coroutines.Dispatchers
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal expect val preferencesPlatformModule: Module
+
+val preferencesModule: Module = module {
+    includes(preferencesPlatformModule)
+
+    singleOf(::DatabaseQueryProvider)
+
+    factoryOf(::PrimitivesSerializer)
+    factoryOf(::PreferencesDbDao) bind PreferencesDao::class
+
+    single<Preferences> {
+        DbPreferences(
+            dao = get(),
+            serializer = get(),
+            dispatcher = Dispatchers.Default
+        )
+    }
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/exception/NoPreferencesKeyException.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/exception/NoPreferencesKeyException.kt
@@ -1,0 +1,3 @@
+package kmp.template.preferences.exception
+
+class NoPreferencesKeyException(key: String): NoSuchElementException("Preferences key: '$key' not found.")

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/exception/UnsupportedValueException.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/exception/UnsupportedValueException.kt
@@ -1,0 +1,3 @@
+package kmp.template.preferences.exception
+
+class UnsupportedValueException(value: Any): IllegalArgumentException("Unsupported value type: ${value::class}")

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/DbPreferences.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/DbPreferences.kt
@@ -1,0 +1,67 @@
+package kmp.template.preferences.internal
+
+import kmp.template.preferences.Preferences
+import kmp.template.preferences.db.DataStore
+import kmp.template.preferences.exception.NoPreferencesKeyException
+import kmp.template.preferences.internal.db.dao.PreferencesDao
+import kmp.template.preferences.internal.serializer.PrimitivesSerializer
+import kmp.template.preferences.internal.serializer.model.SerializedModel
+import kmp.template.preferences.internal.serializer.model.SerializedType
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+@OptIn(ExperimentalTime::class)
+internal class DbPreferences(
+    private val dao: PreferencesDao,
+    private val serializer: PrimitivesSerializer,
+    private val dispatcher: CoroutineDispatcher
+) : Preferences {
+
+    override suspend fun <T : Any> getOrThrow(key: String): T = withContext(dispatcher) {
+        val row = dao.selectBy(key) ?: throw NoPreferencesKeyException(key)
+        serializer.decode(
+            SerializedModel(
+                value = row.encoded,
+                type = SerializedType.valueOf(row.type)
+            )
+        )
+    }
+
+    override suspend fun <T : Any> getOrDefault(key: String, default: T): T = withContext(dispatcher) {
+        val row = dao.selectBy(key) ?: return@withContext default
+        serializer.decode(
+            SerializedModel(
+                value = row.encoded,
+                type = SerializedType.valueOf(row.type)
+            )
+        )
+    }
+
+    override suspend fun <T : Any> set(key: String, value: T) = withContext(dispatcher) {
+        val serialized = serializer.encode(value)
+        val timestamp = Clock.System.now().epochSeconds
+
+        dao.upsert(
+            DataStore(
+                key = key,
+                type = serialized.type.name,
+                encoded = serialized.value,
+                updatedAt = timestamp
+            )
+        )
+    }
+
+    override suspend fun hasKey(key: String): Boolean = withContext(dispatcher) {
+        dao.exists(key)
+    }
+
+    override suspend fun remove(key: String) = withContext(dispatcher) {
+        dao.delete(key)
+    }
+
+    override suspend fun clear() = withContext(dispatcher) {
+        dao.deleteAll()
+    }
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseConstants.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseConstants.kt
@@ -1,0 +1,5 @@
+package kmp.template.preferences.internal.db
+
+internal object DatabaseConstants {
+    const val DB_NAME = "preferences.db"
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseDriverFactory.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseDriverFactory.kt
@@ -1,0 +1,7 @@
+package kmp.template.preferences.internal.db
+
+import app.cash.sqldelight.db.SqlDriver
+
+internal interface DatabaseDriverFactory {
+    fun createDriver(): SqlDriver
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseQueryProvider.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/DatabaseQueryProvider.kt
@@ -1,0 +1,17 @@
+package kmp.template.preferences.internal.db
+
+import kmp.template.preferences.db.PreferencesDb
+import kmp.template.preferences.db.PreferencesDbQueries
+
+internal class DatabaseQueryProvider(
+    private val databaseDriverFactory: DatabaseDriverFactory
+) {
+
+    private val database: PreferencesDb by lazy {
+        PreferencesDb(driver = databaseDriverFactory.createDriver())
+    }
+
+    val preferences: PreferencesDbQueries by lazy {
+        database.preferencesDbQueries
+    }
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/dao/PreferencesDao.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/dao/PreferencesDao.kt
@@ -1,0 +1,16 @@
+package kmp.template.preferences.internal.db.dao
+
+import kmp.template.preferences.db.DataStore
+
+internal interface PreferencesDao {
+
+    suspend fun selectBy(key: String): DataStore?
+
+    suspend fun upsert(dataStore: DataStore)
+
+    suspend fun exists(key: String): Boolean
+
+    suspend fun delete(key: String)
+
+    suspend fun deleteAll()
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/dao/PreferencesDbDao.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/db/dao/PreferencesDbDao.kt
@@ -1,0 +1,29 @@
+package kmp.template.preferences.internal.db.dao
+
+import app.cash.sqldelight.async.coroutines.awaitAsOne
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import kmp.template.preferences.db.DataStore
+import kmp.template.preferences.internal.db.DatabaseQueryProvider
+
+internal class PreferencesDbDao(
+    private val query: DatabaseQueryProvider
+) : PreferencesDao {
+
+    override suspend fun selectBy(key: String): DataStore? =
+        query.preferences.select(key).awaitAsOneOrNull()
+
+    override suspend fun upsert(dataStore: DataStore) {
+        query.preferences.upsert(dataStore)
+    }
+
+    override suspend fun exists(key: String): Boolean =
+        query.preferences.exists(key).awaitAsOne()
+
+    override suspend fun delete(key: String) {
+        query.preferences.delete(key)
+    }
+
+    override suspend fun deleteAll() {
+        query.preferences.deleteAll()
+    }
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/PrimitivesSerializer.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/PrimitivesSerializer.kt
@@ -1,0 +1,38 @@
+package kmp.template.preferences.internal.serializer
+
+import kmp.template.preferences.exception.UnsupportedValueException
+import kmp.template.preferences.internal.serializer.model.SerializedModel
+import kmp.template.preferences.internal.serializer.model.SerializedType
+
+@Suppress("UNCHECKED_CAST")
+internal class PrimitivesSerializer {
+
+    fun encode(value: Any) = SerializedModel(
+        value = value.toString(),
+        type = value.toSerializedType()
+    )
+
+    private fun Any.toSerializedType(): SerializedType = when (this) {
+        is String -> SerializedType.STRING
+        is Int -> SerializedType.INT
+        is Long -> SerializedType.LONG
+        is Boolean -> SerializedType.BOOLEAN
+        is Float -> SerializedType.FLOAT
+        is Double -> SerializedType.DOUBLE
+        else -> throw UnsupportedValueException(this)
+    }
+
+    fun <T : Any> decode(
+        serialized: SerializedModel
+    ): T = when (serialized.type) {
+        SerializedType.STRING -> serialized.value.castOrThrow()
+        SerializedType.INT -> serialized.value.toInt().castOrThrow()
+        SerializedType.LONG -> serialized.value.toLong().castOrThrow()
+        SerializedType.BOOLEAN -> serialized.value.toBooleanStrict().castOrThrow()
+        SerializedType.FLOAT -> serialized.value.toFloat().castOrThrow()
+        SerializedType.DOUBLE -> serialized.value.toDouble().castOrThrow()
+    }
+
+    private fun <T : Any> Any.castOrThrow(): T =
+        this as? T ?: throw UnsupportedValueException(this)
+}

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/model/SerializedModel.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/model/SerializedModel.kt
@@ -1,0 +1,6 @@
+package kmp.template.preferences.internal.serializer.model
+
+internal data class SerializedModel(
+    val value: String,
+    val type: SerializedType
+)

--- a/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/model/SerializedType.kt
+++ b/module/library/preferences/src/commonMain/kotlin/kmp/template/preferences/internal/serializer/model/SerializedType.kt
@@ -1,0 +1,10 @@
+package kmp.template.preferences.internal.serializer.model
+
+internal enum class SerializedType {
+    STRING,
+    INT,
+    LONG,
+    BOOLEAN,
+    FLOAT,
+    DOUBLE
+}

--- a/module/library/preferences/src/commonMain/sqldelight/kmp/template/preferences/db/PreferencesDb.sq
+++ b/module/library/preferences/src/commonMain/sqldelight/kmp/template/preferences/db/PreferencesDb.sq
@@ -1,0 +1,24 @@
+-- Tables
+CREATE TABLE DataStore (
+    key TEXT NOT NULL PRIMARY KEY,
+    type TEXT NOT NULL,
+    encoded TEXT NOT NULL,
+    updatedAt INTEGER NOT NULL
+);
+
+-- Queries
+
+select:
+SELECT * FROM DataStore WHERE key = ?;
+
+upsert:
+INSERT OR REPLACE INTO DataStore(key, type, encoded, updatedAt) VALUES ?;
+
+exists:
+SELECT EXISTS(SELECT 1 FROM DataStore WHERE key = ?);
+
+delete:
+DELETE FROM DataStore WHERE key = ?;
+
+deleteAll:
+DELETE FROM DataStore;

--- a/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/DbPreferencesTest.kt
+++ b/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/DbPreferencesTest.kt
@@ -1,0 +1,121 @@
+package kmp.template.preferences.internal
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kmp.template.preferences.Preferences
+import kmp.template.preferences.db.DataStore
+import kmp.template.preferences.exception.NoPreferencesKeyException
+import kmp.template.preferences.internal.db.dao.PreferencesDao
+import kmp.template.preferences.internal.serializer.PrimitivesSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DbPreferencesTest {
+
+    private val preferencesDao = mock<PreferencesDao>(MockMode.autofill)
+
+    private val tested: Preferences = DbPreferences(
+        dao = preferencesDao,
+        serializer = PrimitivesSerializer(),
+        dispatcher = UnconfinedTestDispatcher()
+    )
+
+    @Test
+    fun `returns value when getOrThrow is called for data stored in DB`() = runTest {
+        everySuspend { preferencesDao.selectBy("name") } returns dataStoreModel
+
+        val result = tested.getOrThrow<String>("name")
+
+        assertEquals("Alice", result)
+    }
+
+    @Test
+    fun `throws exception when getOrThrow is called for data not stored in DB`() = runTest {
+        everySuspend { preferencesDao.selectBy("name") } returns null
+
+        assertFailsWith<NoPreferencesKeyException> {
+            tested.getOrThrow<String>("name")
+        }
+    }
+
+    @Test
+    fun `returns value when getOrDefault is called for data stored in DB`() = runTest {
+        everySuspend { preferencesDao.selectBy("name") } returns dataStoreModel
+
+        val result = tested.getOrDefault("name", "John")
+
+        assertEquals("Alice", result)
+    }
+
+    @Test
+    fun `returns default value when getOrDefault is called for data not stored in DB`() = runTest {
+        everySuspend { preferencesDao.selectBy("name") } returns null
+
+        val result = tested.getOrDefault("name", "John")
+
+        assertEquals("John", result)
+    }
+
+    @Test
+    fun `updates data by using preferences dao when set function is called`() = runTest {
+        lateinit var captured: DataStore
+        everySuspend { preferencesDao.upsert(any()) } calls { captured = it.args[0] as DataStore }
+
+        tested.set("name", "Alice")
+
+        assertEquals(dataStoreModel.key, captured.key)
+        assertEquals(dataStoreModel.type, captured.type)
+        assertEquals(dataStoreModel.encoded, captured.encoded)
+    }
+
+    @Test
+    fun `returns true when hasKey is called for data stored in DB`() = runTest {
+        everySuspend { preferencesDao.exists("name") } returns true
+
+        val result = tested.hasKey("name")
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `returns false when hasKey is called for data not stored in DB`() = runTest {
+        everySuspend { preferencesDao.exists("name") } returns false
+
+        val result = tested.hasKey("name")
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `removes data by using preferences dao when remove function is called`() = runTest {
+        tested.remove("name")
+
+        verifySuspend { preferencesDao.delete("name") }
+    }
+
+    @Test
+    fun `removes all data by using preferences dao when clear function is called`() = runTest {
+        tested.clear()
+
+        verifySuspend { preferencesDao.deleteAll() }
+    }
+
+    companion object Companion {
+        private val dataStoreModel = DataStore(
+            key = "name",
+            type = "STRING",
+            encoded = "Alice",
+            updatedAt = 123
+        )
+    }
+}

--- a/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/db/DatabaseConstantsTest.kt
+++ b/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/db/DatabaseConstantsTest.kt
@@ -1,0 +1,16 @@
+package kmp.template.preferences.internal.db
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DatabaseConstantsTest {
+
+    private val tested = DatabaseConstants
+
+    @Test
+    fun `verify that DB_NAME is equal to expected value`() {
+        val result = tested.DB_NAME
+
+        assertEquals("preferences.db", result)
+    }
+}

--- a/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/serializer/PrimitivesSerializerTest.kt
+++ b/module/library/preferences/src/commonTest/kotlin/kmp/template/preferences/internal/serializer/PrimitivesSerializerTest.kt
@@ -1,0 +1,105 @@
+package kmp.template.preferences.internal.serializer
+
+import kmp.template.preferences.exception.UnsupportedValueException
+import kmp.template.preferences.internal.serializer.model.SerializedModel
+import kmp.template.preferences.internal.serializer.model.SerializedType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PrimitivesSerializerTest {
+
+    private val tested = PrimitivesSerializer()
+
+    @Test
+    fun `verifies encode and decode for value type - string`() {
+        val value = "hello"
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<String>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - int`() {
+        val value = 42
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Int>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - long`() {
+        val value = 123_456_789L
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Long>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - boolean`() {
+        val value = true
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Boolean>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - float`() {
+        val value = 3.14f
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Float>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - double with digits`() {
+        val value = 2.718281828868698
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Double>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `verifies encode and decode for value type - large double`() {
+        val value = 20000000000000000000000000000000000.0
+
+        val encoded = tested.encode(value)
+        val decoded = tested.decode<Double>(encoded)
+
+        assertEquals(value, decoded)
+    }
+
+    @Test
+    fun `throws exception when encode is used with unsupported value type`() {
+        assertFailsWith<UnsupportedValueException> {
+            tested.encode(object {})
+        }
+    }
+
+    @Test
+    fun `throws exception when decode is used with incompatible type`() {
+        assertFailsWith<NumberFormatException> {
+            tested.decode<Boolean>(SerializedModel("bum", SerializedType.INT))
+        }
+    }
+
+    @Test
+    fun `throws exception when decode correct result is casted to invalid Boolean type`() {
+        assertFailsWith<ClassCastException> {
+            val result = tested.decode<Boolean>(SerializedModel("bum", SerializedType.STRING))
+            println("BUM! this should not be printed: $result")
+        }
+    }
+}

--- a/module/library/preferences/src/iosMain/kotlin/kmp/template/preferences/di/PreferencesModule.ios.kt
+++ b/module/library/preferences/src/iosMain/kotlin/kmp/template/preferences/di/PreferencesModule.ios.kt
@@ -1,0 +1,13 @@
+package kmp.template.preferences.di
+
+import kmp.template.preferences.internal.db.DatabaseDriverFactory
+import kmp.template.preferences.internal.db.IosDatabaseDriverFactory
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val preferencesPlatformModule: Module = module {
+
+    singleOf(::IosDatabaseDriverFactory) bind DatabaseDriverFactory::class
+}

--- a/module/library/preferences/src/iosMain/kotlin/kmp/template/preferences/internal/db/IosDatabaseDriverFactory.kt
+++ b/module/library/preferences/src/iosMain/kotlin/kmp/template/preferences/internal/db/IosDatabaseDriverFactory.kt
@@ -1,0 +1,15 @@
+package kmp.template.preferences.internal.db
+
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import kmp.template.preferences.db.PreferencesDb
+
+internal class IosDatabaseDriverFactory : DatabaseDriverFactory {
+
+    override fun createDriver(): SqlDriver =
+        NativeSqliteDriver(
+            schema = PreferencesDb.Schema.synchronous(),
+            name = DatabaseConstants.DB_NAME
+        )
+}

--- a/module/library/preferences/src/jvmMain/kotlin/kmp/template/preferences/di/PreferencesModule.jvm.kt
+++ b/module/library/preferences/src/jvmMain/kotlin/kmp/template/preferences/di/PreferencesModule.jvm.kt
@@ -1,0 +1,13 @@
+package kmp.template.preferences.di
+
+import kmp.template.preferences.internal.db.DatabaseDriverFactory
+import kmp.template.preferences.internal.db.JvmDatabaseDriverFactory
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val preferencesPlatformModule: Module = module {
+
+    singleOf(::JvmDatabaseDriverFactory) bind DatabaseDriverFactory::class
+}

--- a/module/library/preferences/src/jvmMain/kotlin/kmp/template/preferences/internal/db/JvmDatabaseDriverFactory.kt
+++ b/module/library/preferences/src/jvmMain/kotlin/kmp/template/preferences/internal/db/JvmDatabaseDriverFactory.kt
@@ -1,0 +1,22 @@
+package kmp.template.preferences.internal.db
+
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kmp.template.preferences.db.PreferencesDb
+import java.util.Properties as JvmProperties
+
+internal class JvmDatabaseDriverFactory : DatabaseDriverFactory {
+
+    override fun createDriver(): SqlDriver =
+        JdbcSqliteDriver(
+            url = DB_URL_PROTOCOL + DB_DIRECTORY + DatabaseConstants.DB_NAME,
+            properties = JvmProperties(),
+            schema = PreferencesDb.Schema.synchronous()
+        )
+
+    private companion object {
+        const val DB_URL_PROTOCOL = "jdbc:sqlite:"
+        val DB_DIRECTORY: String = System.getProperty("java.io.tmpdir").orEmpty()
+    }
+}

--- a/module/library/preferences/src/wasmJsMain/kotlin/kmp/template/preferences/di/PreferencesModule.web.kt
+++ b/module/library/preferences/src/wasmJsMain/kotlin/kmp/template/preferences/di/PreferencesModule.web.kt
@@ -1,0 +1,13 @@
+package kmp.template.preferences.di
+
+import kmp.template.preferences.internal.db.DatabaseDriverFactory
+import kmp.template.preferences.internal.db.WebDatabaseDriverFactory
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val preferencesPlatformModule: Module = module {
+
+    singleOf(::WebDatabaseDriverFactory) bind DatabaseDriverFactory::class
+}

--- a/module/library/preferences/src/wasmJsMain/kotlin/kmp/template/preferences/internal/db/WebDatabaseDriverFactory.kt
+++ b/module/library/preferences/src/wasmJsMain/kotlin/kmp/template/preferences/internal/db/WebDatabaseDriverFactory.kt
@@ -1,0 +1,21 @@
+package kmp.template.preferences.internal.db
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.worker.WebWorkerDriver
+import org.w3c.dom.Worker
+
+/**
+ * JS bridge is not provided yet, please read documentation to enable it for JS target:
+ * https://sqldelight.github.io/sqldelight/latest/js_sqlite/
+ */
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun createWorker(): Worker = js(
+    """new URL("sqljs.worker.js", import.meta.url)"""
+)
+
+internal class WebDatabaseDriverFactory : DatabaseDriverFactory {
+
+    override fun createDriver(): SqlDriver = WebWorkerDriver(
+        worker = createWorker()
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,5 +26,6 @@ include(
     ":module:library:environment",
     ":module:library:foundation",
     ":module:library:navigation",
-    ":module:library:network"
+    ":module:library:network",
+    ":module:library:preferences"
 )


### PR DESCRIPTION
This commit introduces a new `:module:library:preferences` KMP library module to handle persistent key-value storage. It uses SQLDelight with platform-specific drivers (Android, iOS, JVM) for the underlying database implementation. A no-op driver is provided for the Web target.

- **Preferences Module:**
    - Creates the `Preferences` interface for get/set/remove/clear operations.
    - Implements `DbPreferences` using SQLDelight for data storage and a custom serializer for basic data types.
    - Sets up platform-specific `DatabaseDriverFactory` for Android, iOS, and JVM.
    - Establishes Koin dependency injection (`preferencesModule`) to provide the `Preferences` implementation.

- **Storage Demo Feature:**
    - Adds a new `StorageDemoScreen` to the `sample` feature to demonstrate the usage of the `preferences` module.
    - The screen showcases persisting data across app launches, such as screen launch counters and user-interactive values.
    - Integrates the new screen into the sample feature's navigation and dependency graph.

- **Build & Configuration:**
    - Adds SQLDelight and `kotlinx-datetime` as new dependencies.
    - Includes the `:module:library:preferences` project in the build.
    - Updates the `sample` feature to depend on the new `preferences` module.
    - Adds `linkerOpts` for `sqlite3` in the iOS build configuration.