### PR TITLE
feat: add network demo screen for API communication

### DIFF
--- a/module/feature/sample/build.gradle.kts
+++ b/module/feature/sample/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             implementation(projects.module.library.environment)
             implementation(projects.module.library.foundation)
             implementation(projects.module.library.navigation)
+            implementation(projects.module.library.network)
             implementation(projects.module.library.preferences)
 
             implementation(libs.bundles.compose)
@@ -21,6 +22,9 @@ kotlin {
             implementation(libs.bundles.navigation)
             implementation(libs.koin.compose)
             implementation(libs.koin.viewmodel)
+
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.ktor.client.core)
 
             implementation(libs.kermit)
         }

--- a/module/feature/sample/src/commonMain/composeResources/values/strings.xml
+++ b/module/feature/sample/src/commonMain/composeResources/values/strings.xml
@@ -7,21 +7,22 @@
     <string name="sample_home_card_design_label">Design System</string>
     <string name="sample_home_card_environment_label">Environment</string>
     <string name="sample_home_card_storage_label">Storage Demo</string>
+    <string name="sample_home_card_network_label">Network Demo</string>
 
-    <string name="sample_design_screen_header">Sample Design System</string>
-    <string name="sample_design_fonts_card_header">Fonts</string>
-    <string name="sample_design_icons_card_header">Icons</string>
-    <string name="sample_design_buttons_card_header">Buttons</string>
-    <string name="sample_design_inputs_card_header">Inputs</string>
-    <string name="sample_design_progress_card_header">Progress</string>
-    <string name="sample_design_spacers_card_header">Spacers</string>
+    <string name="design_demo_screen_header">Sample Design System</string>
+    <string name="design_demo_fonts_card_header">Fonts</string>
+    <string name="design_demo_icons_card_header">Icons</string>
+    <string name="design_demo_buttons_card_header">Buttons</string>
+    <string name="design_demo_inputs_card_header">Inputs</string>
+    <string name="design_demo_progress_card_header">Progress</string>
+    <string name="design_demo_spacers_card_header">Spacers</string>
 
-    <string name="sample_environment_screen_header">Environment</string>
-    <string name="sample_environment_card_header">Platform Information</string>
-    <string name="sample_environment_name_label">Platform type: %1$s</string>
-    <string name="sample_environment_app_id_label">Application id: %1$s</string>
-    <string name="sample_environment_version_label">Version name: %1$s</string>
-    <string name="sample_environment_debug_label">Debug build: %1$s</string>
+    <string name="environment_demo_screen_header">Environment</string>
+    <string name="environment_demo_card_header">Platform Information</string>
+    <string name="environment_demo_name_label">Platform type: %1$s</string>
+    <string name="environment_demo_app_id_label">Application id: %1$s</string>
+    <string name="environment_demo_version_label">Version name: %1$s</string>
+    <string name="environment_demo_debug_label">Debug build: %1$s</string>
 
     <string name="storage_demo_screen_header">Storage Demo</string>
     <string name="storage_demo_counter_card_header">Application settings</string>
@@ -38,6 +39,10 @@
     <string name="storage_demo_game_card_button">Clear game</string>
     <string name="storage_demo_clear_storage_header">Clear storage</string>
     <string name="storage_demo_clear_storage_button">Clear full storage</string>
+
+    <string name="network_demo_screen_header">Network Demo</string>
+    <string name="network_demo_card_header">Artworks</string>
+    <string name="network_demo_card_button">Refresh data</string>
 
     <string name="sample_about_screen_header">About Template</string>
     <string name="sample_about_card_header">KMP Project</string>

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/di/SampleModule.kt
@@ -2,21 +2,32 @@ package kmp.template.feature.sample.di
 
 import kmp.template.feature.sample.presentation.SampleViewModel
 import kmp.template.feature.sample.presentation.about.SampleAboutViewModel
-import kmp.template.feature.sample.presentation.design.SampleDesignViewModel
-import kmp.template.feature.sample.presentation.environment.SampleEnvironmentViewModel
+import kmp.template.feature.sample.presentation.design.DesignDemoViewModel
+import kmp.template.feature.sample.presentation.environment.EnvironmentDemoViewModel
 import kmp.template.feature.sample.presentation.home.SampleHomeViewModel
+import kmp.template.feature.sample.presentation.network.NetworkDemoViewModel
+import kmp.template.feature.sample.presentation.network.repository.ArtworksRepository
+import kmp.template.feature.sample.presentation.network.repository.ArtworksRestClient
+import kmp.template.feature.sample.presentation.network.repository.ArtworksRestClient.Companion.API_BASE_URL
 import kmp.template.feature.sample.presentation.storage.StorageDemoViewModel
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 
 val sampleModule: Module = module {
 
     // ViewModels
+    viewModelOf(::DesignDemoViewModel)
+    viewModelOf(::EnvironmentDemoViewModel)
+    viewModelOf(::NetworkDemoViewModel)
     viewModelOf(::SampleAboutViewModel)
-    viewModelOf(::SampleDesignViewModel)
-    viewModelOf(::SampleEnvironmentViewModel)
     viewModelOf(::SampleHomeViewModel)
     viewModelOf(::SampleViewModel)
     viewModelOf(::StorageDemoViewModel)
+
+    // Network
+    single { ArtworksRestClient(httpClient = get { parametersOf(API_BASE_URL) }) }
+    factoryOf(::ArtworksRepository)
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/navigation/SampleRoute.kt
@@ -10,13 +10,16 @@ internal sealed interface SampleRoute : NavKey {
     data object HomeDestination : SampleRoute
 
     @Serializable
-    data object SampleDesignDestination : SampleRoute
+    data object DesignDemoDestination : SampleRoute
 
     @Serializable
-    data object SampleEnvironmentDestination : SampleRoute
+    data object EnvironmentDemoDestination : SampleRoute
 
     @Serializable
     data object StorageDemoDestination : SampleRoute
+
+    @Serializable
+    data object NetworkDemoDestination : SampleRoute
 
     @Serializable
     data object AboutDestination : SampleRoute

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/SampleScreen.kt
@@ -16,14 +16,16 @@ import kmp.template.design.component.navigation.AppNavigationBar
 import kmp.template.design.component.navigation.AppNavigationUiModel
 import kmp.template.design.theme.AppTheme
 import kmp.template.feature.sample.navigation.SampleRoute.AboutDestination
+import kmp.template.feature.sample.navigation.SampleRoute.DesignDemoDestination
+import kmp.template.feature.sample.navigation.SampleRoute.EnvironmentDemoDestination
 import kmp.template.feature.sample.navigation.SampleRoute.HomeDestination
-import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
-import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.navigation.SampleRoute.NetworkDemoDestination
 import kmp.template.feature.sample.navigation.SampleRoute.StorageDemoDestination
 import kmp.template.feature.sample.presentation.about.SampleAboutScreen
-import kmp.template.feature.sample.presentation.design.SampleDesignScreen
-import kmp.template.feature.sample.presentation.environment.SampleEnvironmentScreen
+import kmp.template.feature.sample.presentation.design.DesignDemoScreen
+import kmp.template.feature.sample.presentation.environment.EnvironmentDemoScreen
 import kmp.template.feature.sample.presentation.home.SampleHomeScreen
+import kmp.template.feature.sample.presentation.network.NetworkDemoScreen
 import kmp.template.feature.sample.presentation.storage.StorageDemoScreen
 import kmp.template.navigation.Navigator
 import kmp.template.navigation.compose.NavigatorDisplay
@@ -49,10 +51,11 @@ fun SampleScreen() {
         initialRoute = HomeDestination,
         serializers = SerializersModule {
             polymorphic(NavKey::class) {
-                subclass(subclass = SampleDesignDestination::class, serializer = SampleDesignDestination.serializer())
-                subclass(subclass = SampleEnvironmentDestination::class, serializer = SampleEnvironmentDestination.serializer())
-                subclass(subclass = HomeDestination::class, serializer = HomeDestination.serializer())
                 subclass(subclass = AboutDestination::class, serializer = AboutDestination.serializer())
+                subclass(subclass = DesignDemoDestination::class, serializer = DesignDemoDestination.serializer())
+                subclass(subclass = EnvironmentDemoDestination::class, serializer = EnvironmentDemoDestination.serializer())
+                subclass(subclass = HomeDestination::class, serializer = HomeDestination.serializer())
+                subclass(subclass = NetworkDemoDestination::class, serializer = NetworkDemoDestination.serializer())
                 subclass(subclass = StorageDemoDestination::class, serializer = StorageDemoDestination.serializer())
             }
         }
@@ -66,20 +69,26 @@ fun SampleScreen() {
                     navigator = navigator
                 )
             }
-            entry<SampleDesignDestination> {
-                SampleDesignScreen(
+            entry<DesignDemoDestination> {
+                DesignDemoScreen(
                     viewModel = koinViewModel(),
                     navigator = navigator
                 )
             }
-            entry<SampleEnvironmentDestination> {
-                SampleEnvironmentScreen(
+            entry<EnvironmentDemoDestination> {
+                EnvironmentDemoScreen(
                     viewModel = koinViewModel(),
                     navigator = navigator
                 )
             }
             entry<StorageDemoDestination> {
                 StorageDemoScreen(
+                    viewModel = koinViewModel(),
+                    navigator = navigator
+                )
+            }
+            entry<NetworkDemoDestination> {
+                NetworkDemoScreen(
                     viewModel = koinViewModel(),
                     navigator = navigator
                 )

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoIntent.kt
@@ -1,0 +1,6 @@
+package kmp.template.feature.sample.presentation.design
+
+internal sealed interface DesignDemoIntent {
+
+    data object NavigateBackPressed : DesignDemoIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoScreen.kt
@@ -37,23 +37,23 @@ import kmp.template.design.component.screenstate.ScreenStateContent
 import kmp.template.design.component.screenstate.ScreenStateUiModel
 import kmp.template.design.component.topbar.AppTopCenterBar
 import kmp.template.design.theme.AppTheme
-import kmp.template.feature.sample.presentation.design.SampleDesignIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.design.DesignDemoIntent.NavigateBackPressed
 import kmp.template.foundation.lifecycle.SideEffectDispatcher
 import kmp.template.navigation.Navigator
 import kmp.template.navigation.NavigatorEvent
 import kmp_template.module.feature.sample.generated.resources.Res
-import kmp_template.module.feature.sample.generated.resources.sample_design_buttons_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_fonts_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_icons_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_inputs_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_progress_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_screen_header
-import kmp_template.module.feature.sample.generated.resources.sample_design_spacers_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_buttons_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_fonts_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_icons_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_inputs_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_progress_card_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_screen_header
+import kmp_template.module.feature.sample.generated.resources.design_demo_spacers_card_header
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-internal fun SampleDesignScreen(
-    viewModel: SampleDesignViewModel,
+internal fun DesignDemoScreen(
+    viewModel: DesignDemoViewModel,
     navigator: Navigator
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
@@ -64,24 +64,24 @@ internal fun SampleDesignScreen(
         }
     }
 
-    SampleDesignScreen(
+    DesignDemoScreen(
         viewState = viewState,
-        intent = viewModel::processIntent
+        intent = viewModel::onIntent
     )
 }
 
 @Composable
-private fun SampleDesignScreen(
-    viewState: SampleDesignViewState,
-    intent: (SampleDesignIntent) -> Unit
+private fun DesignDemoScreen(
+    viewState: DesignDemoViewState,
+    intent: (DesignDemoIntent) -> Unit
 ) = AppScaffold(
     topBar = {
-        SampleDesignTopBar(
+        DesignDemoTopBar(
             intent = intent
         )
     },
     content = { contentPadding ->
-        SampleDesignContent(
+        DesignDemoContent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = contentPadding.calculateTopPadding())
@@ -95,11 +95,11 @@ private fun SampleDesignScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SampleDesignTopBar(
-    intent: (SampleDesignIntent) -> Unit
+private fun DesignDemoTopBar(
+    intent: (DesignDemoIntent) -> Unit
 ) = AppTopCenterBar(
     title = {
-        AppText(text = stringResource(Res.string.sample_design_screen_header))
+        AppText(text = stringResource(Res.string.design_demo_screen_header))
     },
     navigationIcon = {
         IconButton(onClick = { intent(NavigateBackPressed) }) {
@@ -109,7 +109,7 @@ private fun SampleDesignTopBar(
 )
 
 @Composable
-private fun SampleDesignContent(
+private fun DesignDemoContent(
     modifier: Modifier,
 ) = LazyColumn(
     modifier = modifier,
@@ -121,17 +121,17 @@ private fun SampleDesignContent(
         vertical = AppTheme.dimensions.spaceSm
     )
 ) {
-    item { SampleDesignTypography() }
-    item { SampleDesignIcons() }
-    item { SampleDesignButtons() }
-    item { SampleDesignInputs() }
-    item { SampleDesignProgress() }
-    item { SampleDesignSpacers() }
+    item { DesignDemoTypography() }
+    item { DesignDemoIcons() }
+    item { DesignDemoButtons() }
+    item { DesignDemoInputs() }
+    item { DesignDemoProgress() }
+    item { DesignDemoSpacers() }
 }
 
 @Composable
-private fun SampleDesignTypography() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_fonts_card_header)
+private fun DesignDemoTypography() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_fonts_card_header)
 ) {
     AppText(text = "Text format: display", style = AppTheme.typography.display)
     AppText(text = "Text format: headline", style = AppTheme.typography.headline)
@@ -143,8 +143,8 @@ private fun SampleDesignTypography() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignIcons() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_icons_card_header)
+private fun DesignDemoIcons() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_icons_card_header)
 ) {
     AppButtonRow(horizontalAlignment = Alignment.Start) {
         AppIcon(icon = AppTheme.icons.home)
@@ -160,8 +160,8 @@ private fun SampleDesignIcons() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignButtons() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_buttons_card_header)
+private fun DesignDemoButtons() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_buttons_card_header)
 ) {
     AppButtonRow(horizontalAlignment = Alignment.Start) {
         AppFilledButton(
@@ -196,8 +196,8 @@ private fun SampleDesignButtons() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignInputs() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_inputs_card_header)
+private fun DesignDemoInputs() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_inputs_card_header)
 ) {
     AppOutlinedInput(
         label = "Empty input",
@@ -220,8 +220,8 @@ private fun SampleDesignInputs() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignProgress() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_progress_card_header)
+private fun DesignDemoProgress() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_progress_card_header)
 ) {
     AppProgressBar()
     AppProgressBar(progress = 0.00f)
@@ -239,8 +239,8 @@ private fun SampleDesignProgress() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignSpacers() = SampleDesignCardItem(
-    title = stringResource(Res.string.sample_design_spacers_card_header)
+private fun DesignDemoSpacers() = DesignDemoCardItem(
+    title = stringResource(Res.string.design_demo_spacers_card_header)
 ) {
     AppButtonRow(horizontalAlignment = Alignment.Start) {
         AppSectionSpacer(modifier = Modifier.background(AppTheme.colors.primary))
@@ -250,7 +250,7 @@ private fun SampleDesignSpacers() = SampleDesignCardItem(
 }
 
 @Composable
-private fun SampleDesignCardItem(
+private fun DesignDemoCardItem(
     title: String,
     content: @Composable ColumnScope.() -> Unit
 ) = AppCard(
@@ -267,8 +267,8 @@ private fun SampleDesignCardItem(
 @ScreenPreview
 @Composable
 private fun ScreenPreview() = AppTheme {
-    SampleDesignScreen(
-        viewState = SampleDesignViewState(
+    DesignDemoScreen(
+        viewState = DesignDemoViewState(
             screenState = ScreenStateUiModel.Content
         ),
         intent = {}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoViewModel.kt
@@ -1,11 +1,11 @@
 package kmp.template.feature.sample.presentation.design
 
 import kmp.template.design.component.screenstate.ScreenStateUiModel
-import kmp.template.feature.sample.presentation.design.SampleDesignIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.design.DesignDemoIntent.NavigateBackPressed
 import kmp.template.foundation.mvi.MviViewModel
 import kmp.template.navigation.NavigatorEvent.NavigateUp
 
-internal class SampleDesignViewModel : MviViewModel<SampleDesignViewState>(SampleDesignViewState()) {
+internal class DesignDemoViewModel : MviViewModel<DesignDemoViewState>(DesignDemoViewState()) {
 
     init {
         initViewState()
@@ -15,7 +15,7 @@ internal class SampleDesignViewModel : MviViewModel<SampleDesignViewState>(Sampl
         copy(screenState = ScreenStateUiModel.Content)
     }
 
-    fun processIntent(intent: SampleDesignIntent) {
+    fun onIntent(intent: DesignDemoIntent) {
         when (intent) {
             is NavigateBackPressed -> onNavigateBackPressed()
         }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/DesignDemoViewState.kt
@@ -3,6 +3,6 @@ package kmp.template.feature.sample.presentation.design
 import kmp.template.design.component.screenstate.ScreenStateUiModel
 import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
 
-internal data class SampleDesignViewState(
+internal data class DesignDemoViewState(
     val screenState: ScreenStateUiModel = Loading()
 )

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/design/SampleDesignIntent.kt
@@ -1,6 +1,0 @@
-package kmp.template.feature.sample.presentation.design
-
-internal sealed interface SampleDesignIntent {
-
-    data object NavigateBackPressed : SampleDesignIntent
-}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoIntent.kt
@@ -1,0 +1,6 @@
+package kmp.template.feature.sample.presentation.environment
+
+internal sealed interface EnvironmentDemoIntent {
+
+    data object NavigateBackPressed : EnvironmentDemoIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoScreen.kt
@@ -13,29 +13,29 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kmp.template.design.annotation.ScreenPreview
 import kmp.template.design.component.base.AppCard
-import kmp.template.design.component.base.AppComponentSpacer
+import kmp.template.design.component.base.AppDivider
+import kmp.template.design.component.base.AppHeadlineTextStyle
 import kmp.template.design.component.base.AppIcon
 import kmp.template.design.component.base.AppScaffold
 import kmp.template.design.component.base.AppText
-import kmp.template.design.component.base.AppTitleTextStyle
 import kmp.template.design.component.topbar.AppTopCenterBar
 import kmp.template.design.theme.AppTheme
-import kmp.template.feature.sample.presentation.environment.SampleEnvironmentIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.environment.EnvironmentDemoIntent.NavigateBackPressed
 import kmp.template.foundation.lifecycle.SideEffectDispatcher
 import kmp.template.navigation.Navigator
 import kmp.template.navigation.NavigatorEvent
 import kmp_template.module.feature.sample.generated.resources.Res
-import kmp_template.module.feature.sample.generated.resources.sample_environment_app_id_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_card_header
-import kmp_template.module.feature.sample.generated.resources.sample_environment_debug_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_name_label
-import kmp_template.module.feature.sample.generated.resources.sample_environment_screen_header
-import kmp_template.module.feature.sample.generated.resources.sample_environment_version_label
+import kmp_template.module.feature.sample.generated.resources.environment_demo_app_id_label
+import kmp_template.module.feature.sample.generated.resources.environment_demo_card_header
+import kmp_template.module.feature.sample.generated.resources.environment_demo_debug_label
+import kmp_template.module.feature.sample.generated.resources.environment_demo_name_label
+import kmp_template.module.feature.sample.generated.resources.environment_demo_screen_header
+import kmp_template.module.feature.sample.generated.resources.environment_demo_version_label
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-internal fun SampleEnvironmentScreen(
-    viewModel: SampleEnvironmentViewModel,
+internal fun EnvironmentDemoScreen(
+    viewModel: EnvironmentDemoViewModel,
     navigator: Navigator
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
@@ -46,24 +46,24 @@ internal fun SampleEnvironmentScreen(
         }
     }
 
-    SampleEnvironmentScreen(
+    EnvironmentDemoScreen(
         viewState = viewState,
-        intent = viewModel::processIntent
+        intent = viewModel::onIntent
     )
 }
 
 @Composable
-private fun SampleEnvironmentScreen(
-    viewState: SampleEnvironmentViewState,
-    intent: (SampleEnvironmentIntent) -> Unit
+private fun EnvironmentDemoScreen(
+    viewState: EnvironmentDemoViewState,
+    intent: (EnvironmentDemoIntent) -> Unit
 ) = AppScaffold(
     topBar = {
-        SampleEnvironmentTopBar(
+        EnvironmentDemoTopBar(
             intent = intent
         )
     },
     content = { contentPadding ->
-        SampleEnvironmentContent(
+        EnvironmentDemoContent(
             viewState = viewState,
             modifier = Modifier
                 .fillMaxWidth()
@@ -74,11 +74,11 @@ private fun SampleEnvironmentScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SampleEnvironmentTopBar(
-    intent: (SampleEnvironmentIntent) -> Unit
+private fun EnvironmentDemoTopBar(
+    intent: (EnvironmentDemoIntent) -> Unit
 ) = AppTopCenterBar(
     title = {
-        AppText(text = stringResource(Res.string.sample_environment_screen_header))
+        AppText(text = stringResource(Res.string.environment_demo_screen_header))
     },
     navigationIcon = {
         IconButton(onClick = { intent(NavigateBackPressed) }) {
@@ -88,8 +88,8 @@ private fun SampleEnvironmentTopBar(
 )
 
 @Composable
-private fun SampleEnvironmentContent(
-    viewState: SampleEnvironmentViewState,
+private fun EnvironmentDemoContent(
+    viewState: EnvironmentDemoViewState,
     modifier: Modifier
 ) = LazyColumn(
     modifier = modifier,
@@ -102,7 +102,7 @@ private fun SampleEnvironmentContent(
     )
 ) {
     item {
-        SampleEnvironmentCard(
+        EnvironmentDemoCard(
             viewState = viewState,
             modifier = Modifier.fillMaxWidth()
         )
@@ -110,28 +110,29 @@ private fun SampleEnvironmentContent(
 }
 
 @Composable
-private fun SampleEnvironmentCard(
-    viewState: SampleEnvironmentViewState,
+private fun EnvironmentDemoCard(
+    viewState: EnvironmentDemoViewState,
     modifier: Modifier
 ) = AppCard(
-    modifier = modifier
+    modifier = modifier,
+    itemPadding = AppTheme.dimensions.spaceMd
 ) {
-    AppTitleTextStyle {
-        AppText(stringResource(Res.string.sample_environment_card_header))
+    AppHeadlineTextStyle {
+        AppText(stringResource(Res.string.environment_demo_card_header))
     }
-    AppComponentSpacer()
+    AppDivider()
 
-    AppText(stringResource(Res.string.sample_environment_name_label, viewState.environmentName))
-    AppText(stringResource(Res.string.sample_environment_app_id_label, viewState.applicationId))
-    AppText(stringResource(Res.string.sample_environment_version_label, viewState.versionName))
-    AppText(stringResource(Res.string.sample_environment_debug_label, viewState.debugLabel))
+    AppText(stringResource(Res.string.environment_demo_name_label, viewState.environmentName))
+    AppText(stringResource(Res.string.environment_demo_app_id_label, viewState.applicationId))
+    AppText(stringResource(Res.string.environment_demo_version_label, viewState.versionName))
+    AppText(stringResource(Res.string.environment_demo_debug_label, viewState.debugLabel))
 }
 
 @ScreenPreview
 @Composable
 private fun ScreenPreview() = AppTheme {
-    SampleEnvironmentScreen(
-        viewState = SampleEnvironmentViewState(
+    EnvironmentDemoScreen(
+        viewState = EnvironmentDemoViewState(
             environmentName = "iOS",
             applicationId = "kmp.template",
             versionName = "1.0.0",

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoViewModel.kt
@@ -1,13 +1,13 @@
 package kmp.template.feature.sample.presentation.environment
 
 import kmp.template.environment.Environment
-import kmp.template.feature.sample.presentation.environment.SampleEnvironmentIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.environment.EnvironmentDemoIntent.NavigateBackPressed
 import kmp.template.foundation.mvi.MviViewModel
 import kmp.template.navigation.NavigatorEvent.NavigateUp
 
-internal class SampleEnvironmentViewModel(
+internal class EnvironmentDemoViewModel(
     private val environment: Environment
-) : MviViewModel<SampleEnvironmentViewState>(SampleEnvironmentViewState()) {
+) : MviViewModel<EnvironmentDemoViewState>(EnvironmentDemoViewState()) {
 
     init {
         initViewState()
@@ -22,7 +22,7 @@ internal class SampleEnvironmentViewModel(
         )
     }
 
-    fun processIntent(intent: SampleEnvironmentIntent) {
+    fun onIntent(intent: EnvironmentDemoIntent) {
         when (intent) {
             is NavigateBackPressed -> onNavigateBackPressed()
         }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/EnvironmentDemoViewState.kt
@@ -1,6 +1,6 @@
 package kmp.template.feature.sample.presentation.environment
 
-internal data class SampleEnvironmentViewState(
+internal data class EnvironmentDemoViewState(
     val environmentName: String = "",
     val applicationId: String = "",
     val versionName: String = "",

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/environment/SampleEnvironmentIntent.kt
@@ -1,6 +1,0 @@
-package kmp.template.feature.sample.presentation.environment
-
-internal sealed interface SampleEnvironmentIntent {
-
-    data object NavigateBackPressed : SampleEnvironmentIntent
-}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeIntent.kt
@@ -2,7 +2,8 @@ package kmp.template.feature.sample.presentation.home
 
 internal sealed interface SampleHomeIntent {
 
-    data object DesignSystemPressed : SampleHomeIntent
-    data object EnvironmentPressed : SampleHomeIntent
+    data object DesignDemoPressed : SampleHomeIntent
+    data object EnvironmentDemoPressed : SampleHomeIntent
     data object StorageDemoPressed : SampleHomeIntent
+    data object NetworkDemoPressed : SampleHomeIntent
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeScreen.kt
@@ -23,8 +23,9 @@ import kmp.template.design.component.base.AppText
 import kmp.template.design.component.screenstate.ScreenStateContent
 import kmp.template.design.component.screenstate.ScreenStateUiModel
 import kmp.template.design.theme.AppTheme
-import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
-import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignDemoPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentDemoPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.NetworkDemoPressed
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.StorageDemoPressed
 import kmp.template.foundation.lifecycle.SideEffectDispatcher
 import kmp.template.navigation.Navigator
@@ -33,6 +34,7 @@ import kmp_template.module.feature.sample.generated.resources.Res
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_design_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_environment_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_header
+import kmp_template.module.feature.sample.generated.resources.sample_home_card_network_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_card_storage_label
 import kmp_template.module.feature.sample.generated.resources.sample_home_screen_header
 import org.jetbrains.compose.resources.stringResource
@@ -52,7 +54,7 @@ internal fun SampleHomeScreen(
 
     SampleHomeScreen(
         viewState = viewState,
-        intent = viewModel::processIntent
+        intent = viewModel::onIntent
     )
 }
 
@@ -116,15 +118,19 @@ private fun SampleHomeCard(
 
     AppFilledButton(
         label = stringResource(Res.string.sample_home_card_design_label),
-        onClick = { intent(DesignSystemPressed) }
+        onClick = { intent(DesignDemoPressed) }
     )
     AppFilledButton(
         label = stringResource(Res.string.sample_home_card_environment_label),
-        onClick = { intent(EnvironmentPressed) }
+        onClick = { intent(EnvironmentDemoPressed) }
     )
     AppFilledButton(
         label = stringResource(Res.string.sample_home_card_storage_label),
         onClick = { intent(StorageDemoPressed) }
+    )
+    AppFilledButton(
+        label = stringResource(Res.string.sample_home_card_network_label),
+        onClick = { intent(NetworkDemoPressed) }
     )
 }
 

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/home/SampleHomeViewModel.kt
@@ -1,11 +1,13 @@
 package kmp.template.feature.sample.presentation.home
 
 import kmp.template.design.component.screenstate.ScreenStateUiModel
-import kmp.template.feature.sample.navigation.SampleRoute.SampleDesignDestination
-import kmp.template.feature.sample.navigation.SampleRoute.SampleEnvironmentDestination
+import kmp.template.feature.sample.navigation.SampleRoute.DesignDemoDestination
+import kmp.template.feature.sample.navigation.SampleRoute.EnvironmentDemoDestination
+import kmp.template.feature.sample.navigation.SampleRoute.NetworkDemoDestination
 import kmp.template.feature.sample.navigation.SampleRoute.StorageDemoDestination
-import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignSystemPressed
-import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.DesignDemoPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.EnvironmentDemoPressed
+import kmp.template.feature.sample.presentation.home.SampleHomeIntent.NetworkDemoPressed
 import kmp.template.feature.sample.presentation.home.SampleHomeIntent.StorageDemoPressed
 import kmp.template.foundation.mvi.MviViewModel
 import kmp.template.navigation.NavigatorEvent.NavigateTo
@@ -20,23 +22,28 @@ internal class SampleHomeViewModel : MviViewModel<SampleHomeViewState>(SampleHom
         copy(screenState = ScreenStateUiModel.Content)
     }
 
-    fun processIntent(intent: SampleHomeIntent) {
+    fun onIntent(intent: SampleHomeIntent) {
         when (intent) {
-            is DesignSystemPressed -> onDesignSystemPressed()
-            is EnvironmentPressed -> onEnvironmentPressed()
+            is DesignDemoPressed -> onDesignDemoPressed()
+            is EnvironmentDemoPressed -> onEnvironmentDemoPressed()
             is StorageDemoPressed -> onStorageDemoPressed()
+            is NetworkDemoPressed -> onNetworkDemoPressed()
         }
     }
 
-    private fun onDesignSystemPressed() {
-        emitSideEffect(NavigateTo(SampleDesignDestination))
+    private fun onDesignDemoPressed() {
+        emitSideEffect(NavigateTo(DesignDemoDestination))
     }
 
-    private fun onEnvironmentPressed() {
-        emitSideEffect(NavigateTo(SampleEnvironmentDestination))
+    private fun onEnvironmentDemoPressed() {
+        emitSideEffect(NavigateTo(EnvironmentDemoDestination))
     }
 
     private fun onStorageDemoPressed() {
         emitSideEffect(NavigateTo(StorageDemoDestination))
+    }
+
+    private fun onNetworkDemoPressed() {
+        emitSideEffect(NavigateTo(NetworkDemoDestination))
     }
 }

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoIntent.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoIntent.kt
@@ -1,0 +1,7 @@
+package kmp.template.feature.sample.presentation.network
+
+internal sealed interface NetworkDemoIntent {
+
+    data object RefreshListPressed : NetworkDemoIntent
+    data object NavigateBackPressed : NetworkDemoIntent
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoScreen.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoScreen.kt
@@ -1,0 +1,169 @@
+package kmp.template.feature.sample.presentation.network
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kmp.template.design.annotation.ScreenPreview
+import kmp.template.design.component.base.AppButtonRow
+import kmp.template.design.component.base.AppCard
+import kmp.template.design.component.base.AppDivider
+import kmp.template.design.component.base.AppFilledButton
+import kmp.template.design.component.base.AppHeadlineTextStyle
+import kmp.template.design.component.base.AppIcon
+import kmp.template.design.component.base.AppItemSpacer
+import kmp.template.design.component.base.AppScaffold
+import kmp.template.design.component.base.AppText
+import kmp.template.design.component.screenstate.ScreenStateContent
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.topbar.AppTopCenterBar
+import kmp.template.design.theme.AppTheme
+import kmp.template.feature.sample.presentation.network.NetworkDemoIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.network.NetworkDemoIntent.RefreshListPressed
+import kmp.template.foundation.lifecycle.SideEffectDispatcher
+import kmp.template.navigation.Navigator
+import kmp.template.navigation.NavigatorEvent
+import kmp_template.module.feature.sample.generated.resources.Res
+import kmp_template.module.feature.sample.generated.resources.network_demo_card_button
+import kmp_template.module.feature.sample.generated.resources.network_demo_card_header
+import kmp_template.module.feature.sample.generated.resources.network_demo_screen_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun NetworkDemoScreen(
+    viewModel: NetworkDemoViewModel,
+    navigator: Navigator
+) {
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SideEffectDispatcher(viewModel.sideEffect) {
+        when (it) {
+            is NavigatorEvent -> navigator.navigate(it)
+        }
+    }
+
+    NetworkDemoScreen(
+        viewState = viewState,
+        intent = viewModel::onIntent
+    )
+}
+
+@Composable
+private fun NetworkDemoScreen(
+    viewState: NetworkDemoViewState,
+    intent: (NetworkDemoIntent) -> Unit
+) = AppScaffold(
+    topBar = {
+        NetworkDemoTopBar(
+            intent = intent
+        )
+    },
+    content = { contentPadding ->
+        if (viewState.screenState is ScreenStateUiModel.Content) {
+            NetworkDemoContent(
+                viewState = viewState,
+                intent = intent,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = contentPadding.calculateTopPadding())
+            )
+        } else {
+            ScreenStateContent(
+                screenState = viewState.screenState,
+                modifier = Modifier.fillMaxSize(),
+                onFilledButtonClick = { intent(RefreshListPressed) }
+            )
+        }
+    }
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NetworkDemoTopBar(
+    intent: (NetworkDemoIntent) -> Unit
+) = AppTopCenterBar(
+    title = {
+        AppText(text = stringResource(Res.string.network_demo_screen_header))
+    },
+    navigationIcon = {
+        IconButton(onClick = { intent(NavigateBackPressed) }) {
+            AppIcon(icon = AppTheme.icons.arrowBack)
+        }
+    }
+)
+
+@Composable
+private fun NetworkDemoContent(
+    viewState: NetworkDemoViewState,
+    intent: (NetworkDemoIntent) -> Unit,
+    modifier: Modifier
+) = LazyColumn(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(
+        space = AppTheme.dimensions.spaceSm
+    ),
+    contentPadding = PaddingValues(
+        horizontal = AppTheme.dimensions.spaceMd,
+        vertical = AppTheme.dimensions.spaceSm
+    )
+) {
+    item {
+        NetworkDemoArtworkCard(
+            viewState = viewState,
+            intent = intent,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun NetworkDemoArtworkCard(
+    viewState: NetworkDemoViewState,
+    intent: (NetworkDemoIntent) -> Unit,
+    modifier: Modifier
+) = AppCard(
+    modifier = modifier,
+    itemPadding = AppTheme.dimensions.spaceMd
+) {
+    AppHeadlineTextStyle {
+        AppText(stringResource(Res.string.network_demo_card_header))
+    }
+    AppDivider()
+    viewState.artworks.forEach { artwork ->
+        Column {
+            AppText(text = artwork.title)
+            AppText(text = artwork.artist)
+        }
+    }
+    AppItemSpacer()
+    AppButtonRow(
+        horizontalAlignment = Alignment.End,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        AppFilledButton(
+            label = stringResource(Res.string.network_demo_card_button),
+            onClick = { intent(RefreshListPressed) }
+        )
+    }
+}
+
+@ScreenPreview
+@Composable
+private fun ScreenPreview() = AppTheme {
+    NetworkDemoScreen(
+        viewState = NetworkDemoViewState(
+            screenState = ScreenStateUiModel.Content
+        ),
+        intent = {}
+    )
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoViewModel.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoViewModel.kt
@@ -1,0 +1,53 @@
+package kmp.template.feature.sample.presentation.network
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Content
+import kmp.template.design.component.screenstate.ScreenStateUiModel.ErrorState
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+import kmp.template.feature.sample.presentation.network.NetworkDemoIntent.NavigateBackPressed
+import kmp.template.feature.sample.presentation.network.NetworkDemoIntent.RefreshListPressed
+import kmp.template.feature.sample.presentation.network.repository.ArtworksRepository
+import kmp.template.foundation.extension.runWithMinDuration
+import kmp.template.foundation.mvi.MviViewModel
+import kmp.template.navigation.NavigatorEvent.NavigateUp
+import kotlinx.coroutines.Job
+
+internal class NetworkDemoViewModel(
+    private val artworksRepository: ArtworksRepository
+) : MviViewModel<NetworkDemoViewState>(NetworkDemoViewState()) {
+
+    private var refreshJob: Job
+
+    init {
+        refreshJob = refreshArtworksList()
+    }
+
+    fun onIntent(intent: NetworkDemoIntent) {
+        when (intent) {
+            is RefreshListPressed -> onRefreshListPressed()
+            is NavigateBackPressed -> onNavigateBackPressed()
+        }
+    }
+
+    private fun onRefreshListPressed() {
+        if (refreshJob.isCompleted) {
+            refreshJob = refreshArtworksList()
+        }
+    }
+
+    private fun refreshArtworksList() = launch {
+        transform { copy(screenState = LOADING_STATE) }
+
+        runWithMinDuration { artworksRepository.getArtworks() }
+            .onSuccess { transform { copy(screenState = Content, artworks = it) } }
+            .onFailure { transform { copy(screenState = ERROR_STATE) } }
+    }
+
+    private fun onNavigateBackPressed() {
+        emitSideEffect(NavigateUp())
+    }
+
+    companion object {
+        private val LOADING_STATE = Loading(message = "Loading data from server...")
+        private val ERROR_STATE = ErrorState(message = "Data not available :(", filledButtonText = "Refresh data")
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoViewState.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/NetworkDemoViewState.kt
@@ -1,0 +1,10 @@
+package kmp.template.feature.sample.presentation.network
+
+import kmp.template.design.component.screenstate.ScreenStateUiModel
+import kmp.template.design.component.screenstate.ScreenStateUiModel.Loading
+import kmp.template.feature.sample.presentation.network.model.Artwork
+
+internal data class NetworkDemoViewState(
+    val screenState: ScreenStateUiModel = Loading(),
+    val artworks: List<Artwork> = emptyList()
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/model/Artwork.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/model/Artwork.kt
@@ -1,0 +1,12 @@
+package kmp.template.feature.sample.presentation.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class Artwork(
+    @SerialName("id") val id: Long = 0L,
+    @SerialName("title") val title: String = "",
+    @SerialName("artist_display") val artist: String = "",
+    @SerialName("medium_display") val display: String = ""
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/model/ArtworksResponse.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/model/ArtworksResponse.kt
@@ -1,0 +1,8 @@
+package kmp.template.feature.sample.presentation.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ArtworksResponse(
+    val data: List<Artwork>
+)

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/repository/ArtworksRepository.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/repository/ArtworksRepository.kt
@@ -1,0 +1,12 @@
+package kmp.template.feature.sample.presentation.network.repository
+
+import kmp.template.feature.sample.presentation.network.model.Artwork
+
+internal class ArtworksRepository(
+    private val artworksRestClient: ArtworksRestClient
+) {
+
+    suspend fun getArtworks(): Result<List<Artwork>> = runCatching {
+        artworksRestClient.getArtworks()
+    }
+}

--- a/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/repository/ArtworksRestClient.kt
+++ b/module/feature/sample/src/commonMain/kotlin/kmp/template/feature/sample/presentation/network/repository/ArtworksRestClient.kt
@@ -1,0 +1,29 @@
+package kmp.template.feature.sample.presentation.network.repository
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.path
+import kmp.template.feature.sample.presentation.network.model.Artwork
+import kmp.template.feature.sample.presentation.network.model.ArtworksResponse
+
+internal class ArtworksRestClient(
+    private val httpClient: HttpClient
+) {
+
+    suspend fun getArtworks(): List<Artwork> =
+        httpClient.get {
+            url {
+                path("api", "v1", "artworks")
+                parameters.append("limit", API_LIMIT)
+                parameters.append("fields", API_FIELDS)
+            }
+        }.body<ArtworksResponse>().data
+
+    companion object {
+
+        internal const val API_BASE_URL = "https://api.artic.edu/"
+        internal const val API_LIMIT = "20"
+        internal const val API_FIELDS = "id,title,artist_display,medium_display"
+    }
+}

--- a/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/extension/AnyExt.kt
+++ b/module/library/foundation/src/commonMain/kotlin/kmp/template/foundation/extension/AnyExt.kt
@@ -1,0 +1,20 @@
+package kmp.template.foundation.extension
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+suspend fun <T> runWithMinDuration(
+    minDuration: Duration = 300.milliseconds,
+    block: suspend () -> T
+): T = coroutineScope {
+    val delayJob = launch { delay(minDuration) }
+    val blockJob = async { block() }
+
+    blockJob.await().also {
+        delayJob.join()
+    }
+}

--- a/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientFactory.kt
+++ b/module/library/network/src/commonMain/kotlin/kmp/template/network/client/HttpClientFactory.kt
@@ -20,6 +20,7 @@ internal object HttpClientFactory {
                 Json {
                     ignoreUnknownKeys = true
                     useAlternativeNames = false
+                    coerceInputValues = true
                 }
             )
         }


### PR DESCRIPTION
This commit introduces a new "Network Demo" feature to showcase API communication using Ktor. It adds a new screen that fetches and displays a list of artworks from the Art Institute of Chicago API. The existing "Design" and "Environment" demo screens have also been renamed for consistency.

- **Network Demo Feature:**
    - Adds `NetworkDemoScreen` to display a list of artworks.
    - Implements `ArtworksRestClient` using Ktor to fetch data from `https://api.artic.edu/`.
    - Creates `ArtworksRepository` to abstract the data source.
    - Includes a `Refresh` button to re-fetch the data.
    - Introduces `NetworkDemoViewModel` to manage state and API calls.
    - Handles loading, content, and error states.

- **Sample Feature Refactoring:**
    - Renames `SampleDesignScreen` to `DesignDemoScreen` and `SampleEnvironmentScreen` to `EnvironmentDemoScreen` for better naming consistency.
    - Updates corresponding ViewModels, Intents, ViewStates, navigation routes, and string resources.
    - Adds a "Network Demo" button to the `SampleHomeScreen`.

- **Dependency Injection & Build:**
    - Configures Koin to provide `ArtworksRestClient`, `ArtworksRepository`, and `NetworkDemoViewModel`.
    - Adds the `:module:library:network` dependency to the `sample` feature module.