### PR TITLE
ci: enable manual workflow triggers

### DIFF
--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -1,6 +1,7 @@
 # GitHub project compilation workflow
 name: "Project Build"
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/.github/workflows/project-check.yml
+++ b/.github/workflows/project-check.yml
@@ -1,6 +1,7 @@
 # GitHub project verification workflow
 name: "Project Check"
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
This commit adds `workflow_dispatch` to the `project-check.yml` and `project-build.yml` GitHub Actions workflows.

This change allows for the manual triggering of the "Project Check" and "Project Build" workflows directly from the GitHub UI, in addition to their existing triggers (`pull_request` and `push` respectively).